### PR TITLE
Update to WebStandardStreamableHTTPServerTransport

### DIFF
--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -8,7 +8,7 @@
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { DocumentStore } from "./store";
 import { indexAllCollections } from "./indexer";
 import { singleRootConfig } from "./types";
@@ -55,7 +55,7 @@ async function main() {
         // For each incoming request, create server + transport
         // This is the stateless pattern from the MCP SDK docs
         const server = createMcpServer(store);
-        const transport = new StreamableHTTPServerTransport({
+        const transport = new WebStandardStreamableHTTPServerTransport({
           sessionIdGenerator: undefined, // stateless
         });
 


### PR DESCRIPTION
## Summary
Updated the HTTP server transport implementation to use the new `WebStandardStreamableHTTPServerTransport` class from the MCP SDK, replacing the previous `StreamableHTTPServerTransport`.

## Changes
- Updated import statement to use `WebStandardStreamableHTTPServerTransport` from `webStandardStreamableHttp.js` module
- Updated transport instantiation to use the new `WebStandardStreamableHTTPServerTransport` class
- Maintained existing configuration with `sessionIdGenerator: undefined` for stateless operation

## Details
This change aligns with updates to the MCP SDK's HTTP transport layer, adopting the web standard-compliant implementation for improved compatibility and standards adherence.