### PR TITLE
Add registry metadata for public MCP directory submissions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 joesaby
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,31 @@
   "version": "1.0.0",
   "description": "Agentic document retrieval over markdown — BM25 search + tree navigation via MCP. Inspired by PageIndex and Pagefind.",
   "type": "module",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "rag",
+    "bm25",
+    "markdown",
+    "documentation",
+    "llm",
+    "ai",
+    "search",
+    "tree-navigation",
+    "claude"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joesaby/doctree-mcp.git"
+  },
+  "homepage": "https://github.com/joesaby/doctree-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/joesaby/doctree-mcp/issues"
+  },
+  "license": "MIT",
+  "engines": {
+    "bun": ">=1.3.8"
+  },
   "scripts": {
     "serve": "bun run src/server.ts",
     "serve:http": "bun run src/server-http.ts",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,42 @@
+name: doctree-mcp
+description: Agentic document retrieval over markdown — BM25 search + tree navigation via MCP. No vector DB, no embeddings, no LLM calls at index time.
+license: MIT
+homepage: https://github.com/joesaby/doctree-mcp
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - docsRoot
+    properties:
+      docsRoot:
+        type: string
+        description: Absolute path to your markdown repository root
+      docsGlob:
+        type: string
+        default: "**/*.md"
+        description: Glob pattern for finding markdown files
+      maxDepth:
+        type: number
+        default: 6
+        description: Maximum heading depth to index (1-6)
+      summaryLength:
+        type: number
+        default: 200
+        description: Characters to include in node summaries
+      glossaryPath:
+        type: string
+        description: Path to glossary.json for query expansion (default: $DOCS_ROOT/glossary.json)
+  commandFunction: |-
+    (config) => ({
+      command: "bun",
+      args: ["run", "src/server.ts"],
+      env: {
+        DOCS_ROOT: config.docsRoot,
+        ...(config.docsGlob && { DOCS_GLOB: config.docsGlob }),
+        ...(config.maxDepth && { MAX_DEPTH: String(config.maxDepth) }),
+        ...(config.summaryLength && { SUMMARY_LENGTH: String(config.summaryLength) }),
+        ...(config.glossaryPath && { GLOSSARY_PATH: config.glossaryPath }),
+      }
+    })


### PR DESCRIPTION
## Summary

- Add `LICENSE` file (MIT) — required by most MCP registries
- Add `smithery.yaml` — enables registration on Smithery.ai
- Update `package.json` with `keywords`, `repository`, `homepage`, `bugs`, `license`, and `engines` fields — needed for npm registry discoverability and to declare the Bun ≥ 1.3.8 requirement

## Test plan

- [ ] Verify LICENSE file renders correctly on GitHub repo page
- [ ] Verify smithery.yaml is valid YAML
- [ ] Verify package.json is valid JSON (`bun install` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)