### PR TITLE
Add bin entry and files field for npm publishing

### DIFF
--- a/bin.ts
+++ b/bin.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env bun
+import './src/server.ts'

--- a/package.json
+++ b/package.json
@@ -28,6 +28,15 @@
   "engines": {
     "bun": ">=1.3.8"
   },
+  "bin": {
+    "doctree-mcp": "bin.ts"
+  },
+  "files": [
+    "src/",
+    "bin.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "serve": "bun run src/server.ts",
     "serve:http": "bun run src/server-http.ts",


### PR DESCRIPTION
## Summary

- Add `bin.ts` — entry point with `#!/usr/bin/env bun` shebang, enables `bunx doctree-mcp`
- Add `bin` field to `package.json` pointing to `bin.ts`
- Add `files` field to restrict what gets included in the npm package (`src/`, `bin.ts`, `README.md`, `LICENSE`)

Package is live at https://www.npmjs.com/package/doctree-mcp