### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doctree-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "mcpName": "io.github.joesaby/doctree-mcp",
   "description": "Agentic document retrieval over markdown — BM25 search + tree navigation via MCP. Inspired by PageIndex and Pagefind.",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps package version to `1.0.2` to match the npm release published with the `bin.ts` shebang fix.

**Changes in this release (since 1.0.1):**
- Fix `bin.ts` shebang (`#!/usr/bin/env -S bun run`) so `bunx doctree-mcp` works when Bun is not in `/usr/local/bin`
- Update Quick Start to use `bunx doctree-mcp` — no clone needed
- Fix node ID format in README workflow example (full path `docs:auth:n2`, not short `n2`)