### PR TITLE
Rewrite README around Getting Started and Retrieve/Curate/Add workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,55 @@
 # doctree-mcp
 
-Agentic document retrieval over markdown — BM25 search + tree navigation via MCP.
+Give your AI agent a markdown knowledge base it can search, browse, and write to — no vector DB, no embeddings, no LLM calls at index time.
 
-Give an AI agent structured access to your markdown docs: it searches with BM25, reads the outline, reasons about which sections matter, and retrieves only what it needs. No vector DB, no embeddings, no LLM calls at index time.
+doctree-mcp is an [MCP](https://modelcontextprotocol.io/) server that indexes your markdown files and exposes them as structured tools. Your agent gets BM25 search, a navigable table of contents, and (optionally) the ability to write new docs — turning any folder of `.md` files into a living knowledge base.
 
-With the optional **wiki curation** tools, your AI agent can also **write** new documentation — turning doctree-mcp into an [LLM-maintained wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) where the agent handles the bookkeeping while you curate the sources.
+## Getting Started
 
-## Why
+### 1. Create a docs folder
 
-Standard RAG gives agents a bag of loosely relevant paragraphs. This gives them a **table of contents they can reason over**, plus a search engine that actually ranks by relevance.
+Any folder of markdown files works. Start simple:
 
 ```
-search_documents("auth token refresh")     → find candidate docs (BM25 ranked)
-get_tree("docs:auth:middleware")           → see the heading hierarchy
-  [n4] ## Token Refresh Flow (180 words)
-    [n5] ### Automatic Refresh (90 words)
-    [n6] ### Manual Refresh API (150 words)
-    [n7] ### Error Handling (200 words)
-navigate_tree("docs:auth:middleware", "docs:auth:middleware:n4") → get exactly n4+n5+n6+n7
+my-project/
+├── docs/
+│   ├── setup.md
+│   ├── architecture.md
+│   └── runbooks/
+│       ├── deploy.md
+│       └── rollback.md
+└── .mcp.json          ← MCP configuration (created in step 2)
 ```
 
-Context budget: **2K-8K tokens** with precise content, vs 4K-20K tokens of noisy chunks from vector RAG.
+Your markdown files work best with frontmatter, but it's not required — doctree-mcp infers what it can:
 
-## Quick Start
+```markdown
+---
+title: "Deploy Runbook"
+tags: [deploy, production, ci-cd]
+type: runbook
+category: operations
+---
 
-```bash
-# Install Bun if you don't have it
-curl -fsSL https://bun.com/install | bash
+# Deploy Runbook
 
-# Run directly — no clone needed
-DOCS_ROOT=/path/to/your/markdown/docs bunx doctree-mcp
+## Prerequisites
+
+You need access to the CI/CD pipeline and production cluster credentials...
 ```
 
-### Claude Desktop Configuration
+When frontmatter is missing, doctree-mcp falls back gracefully:
+- **title** — uses first `# Heading`, then filename
+- **type** — inferred from directory name (`runbooks/` → `runbook`, `guides/` → `guide`)
+- **description** — extracted from the first paragraph
 
-```json
-{
-  "mcpServers": {
-    "doctree": {
-      "command": "bunx",
-      "args": ["doctree-mcp"],
-      "env": {
-        "DOCS_ROOT": "/path/to/your/markdown/docs"
-      }
-    }
-  }
-}
-```
+### 2. Connect to your AI agent
 
-### Claude Code Configuration
+Install [Bun](https://bun.sh) if you don't have it, then configure your agent:
 
-Add to your project's `.mcp.json`:
+#### Claude Code
+
+Add `.mcp.json` to your project root:
 
 ```json
 {
@@ -66,7 +65,9 @@ Add to your project's `.mcp.json`:
 }
 ```
 
-To enable wiki write mode (lets the agent create new docs):
+#### Claude Desktop
+
+Add to your [Claude Desktop config](https://modelcontextprotocol.io/quickstart/user):
 
 ```json
 {
@@ -75,15 +76,14 @@ To enable wiki write mode (lets the agent create new docs):
       "command": "bunx",
       "args": ["doctree-mcp"],
       "env": {
-        "DOCS_ROOT": "./docs",
-        "WIKI_WRITE": "1"
+        "DOCS_ROOT": "/absolute/path/to/your/docs"
       }
     }
   }
 }
 ```
 
-### Cursor Configuration
+#### Cursor
 
 Add to `.cursor/mcp.json` in your project root:
 
@@ -101,97 +101,264 @@ Add to `.cursor/mcp.json` in your project root:
 }
 ```
 
-### Run from source
+That's it. When your agent starts, doctree-mcp indexes your markdown files and makes them available through 5 tools (plus 3 more for writing, if enabled).
+
+### 3. Enable writing (optional)
+
+To let your agent create and update docs, add `WIKI_WRITE`:
+
+```json
+{
+  "mcpServers": {
+    "doctree": {
+      "command": "bunx",
+      "args": ["doctree-mcp"],
+      "env": {
+        "DOCS_ROOT": "./docs",
+        "WIKI_WRITE": "1"
+      }
+    }
+  }
+}
+```
+
+This unlocks 3 additional wiki curation tools with safety guards: path containment, frontmatter validation, and duplicate detection.
+
+---
+
+## How It Works: Retrieve, Curate, Add
+
+doctree-mcp gives your agent three capabilities over your docs.
+
+### Retrieve: Search and navigate existing docs
+
+Your agent searches, browses the outline, and reads exactly the sections it needs:
+
+```
+Agent: I need to understand the token refresh flow.
+
+→ search_documents("token refresh")
+  #1  auth/middleware.md § Token Refresh Flow       score: 12.4
+  #2  auth/oauth.md § Refresh Token Lifecycle       score: 8.7
+
+→ get_tree("docs:auth:middleware")
+  [n1] # Auth Middleware (450 words)
+    [n4] ## Token Refresh Flow (180 words)
+      [n5] ### Automatic Refresh (90 words)
+      [n6] ### Manual Refresh API (150 words)
+      [n7] ### Error Handling (200 words)
+
+→ navigate_tree("docs:auth:middleware", "n4")
+  Returns n4 + n5 + n6 + n7 — the full section with all subsections.
+```
+
+This is more precise than vector RAG. Instead of getting a bag of loosely related paragraphs, your agent sees the document structure, reasons about which sections matter, and retrieves only what it needs — typically **2K-8K tokens** vs. 4K-20K from chunked retrieval.
+
+**The 5 retrieval tools:**
+
+| Tool | What it does |
+|------|-------------|
+| `list_documents` | Browse the catalog. Filter by tag or keyword. See facet counts and cross-references. |
+| `search_documents` | BM25 keyword search. Facet filters, glossary expansion, auto-inlined top results. |
+| `get_tree` | Table of contents for a document — headings, word counts, summaries. No content. |
+| `get_node_content` | Full text of specific sections by node ID. Up to 10 at once. |
+| `navigate_tree` | A section and all its descendants in one call. |
+
+### Curate: Check before writing
+
+Before your agent writes new content, it can check what already exists:
+
+```
+Agent: I want to document our JWT validation process.
+
+→ find_similar("JWT validation middleware checks the token signature,
+               extracts claims, and verifies expiration...")
+  Match: auth/middleware.md (overlap: 0.42) — consider updating instead of creating new
+
+→ draft_wiki_entry(topic: "JWT Validation", raw_content: "...")
+  Suggested path: jwt-validation.md
+  Inferred frontmatter: { type: "reference", category: "auth", tags: ["jwt", "auth"] }
+  Glossary hits: JWT → "JSON Web Token"
+  Warning: Similar content exists in auth/middleware.md
+```
+
+This prevents duplicate docs from accumulating and helps your agent slot new content into the right place.
+
+### Add: Write validated docs
+
+Once your agent has a draft, it writes with guardrails:
+
+```
+→ write_wiki_entry(
+    path: "auth/jwt-validation.md",
+    frontmatter: {
+      title: "JWT Validation",
+      type: "reference",
+      category: "auth",
+      tags: ["jwt", "auth", "middleware"]
+    },
+    content: "# JWT Validation\n\n## How It Works\n\n...",
+    dry_run: true          ← validate first, don't write yet
+  )
+  Status: dry_run_ok
+  Warnings: []
+
+→ write_wiki_entry(
+    path: "auth/jwt-validation.md",
+    frontmatter: { ... },
+    content: "...",
+    dry_run: false          ← now write for real
+  )
+  Status: written
+  Doc ID: docs:auth:jwt-validation
+```
+
+**The 3 write tools** (enabled with `WIKI_WRITE=1`):
+
+| Tool | What it does |
+|------|-------------|
+| `find_similar` | Duplicate detection — checks proposed content against existing docs. |
+| `draft_wiki_entry` | Scaffold generator — suggests path, frontmatter, tags, backlinks. |
+| `write_wiki_entry` | Validated write with path containment, schema checks, duplicate guards, dry-run mode. |
+
+**Safety features:**
+- Path containment — can't write outside the wiki root
+- Frontmatter validation — enforces key naming, value types
+- Duplicate detection — warns when similar content already exists
+- Dry-run mode — validate everything without touching disk
+- Overwrite protection — won't clobber existing files unless you opt in
+
+---
+
+## The LLM Wiki Pattern
+
+doctree-mcp supports using your agent as a wiki maintainer, inspired by [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) concept:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Raw Sources     │     │  The Wiki        │     │  The Schema      │
+│  (immutable)     │ ──→ │  (LLM-maintained)│ ←── │  (you define)    │
+│                  │     │                  │     │                  │
+│  meeting notes   │     │  structured docs │     │  CLAUDE.md rules │
+│  Slack threads   │     │  runbooks        │     │  frontmatter     │
+│  incident logs   │     │  how-to guides   │     │  directory layout │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+**Workflow:**
+1. You dump raw material into a source folder
+2. Your agent reads, synthesizes, and writes structured wiki entries
+3. `CLAUDE.md` or similar files define the structure and conventions
+4. doctree-mcp handles search, deduplication, and validation
+
+See [docs/LLM-WIKI-GUIDE.md](docs/LLM-WIKI-GUIDE.md) for the full walkthrough.
+
+---
+
+## Frontmatter for Better Search
+
+Frontmatter improves search ranking and faceted filtering. Here's what doctree-mcp uses:
+
+```yaml
+---
+title: "Descriptive Title"
+description: "One-line summary — boosts search ranking"
+tags: [relevant, terms, here]
+type: runbook            # runbook | guide | reference | tutorial | architecture | adr | ...
+category: auth           # any domain grouping
+---
+```
+
+All frontmatter fields (except reserved ones like `title`, `description`, `date`) become **filter facets** you can use in search:
+
+```
+search_documents("auth", filters: { "type": "runbook", "tags": ["production"] })
+```
+
+doctree-mcp also auto-detects **content facets** from your markdown: code languages, link presence, and code block presence.
+
+## Glossary & Query Expansion
+
+Create a `glossary.json` in your docs root to enable bidirectional query expansion:
+
+```json
+{
+  "CLI": ["command line interface"],
+  "K8s": ["kubernetes"],
+  "JWT": ["json web token"]
+}
+```
+
+Now searching "CLI" also matches "command line interface" and vice versa.
+
+doctree-mcp also **auto-extracts** acronym definitions from your content — patterns like "TLS (Transport Layer Security)" are detected and added to the glossary automatically.
+
+## Multiple Collections
+
+Index docs from multiple directories with per-collection search weights:
+
+```json
+{
+  "env": {
+    "DOCS_ROOTS": "./wiki:1.0,./api-docs:0.8,./meeting-notes:0.3"
+  }
+}
+```
+
+Higher-weighted collections rank higher in search results — useful when your wiki is authoritative but you still want meeting notes searchable.
+
+## Running from Source
 
 ```bash
 git clone https://github.com/joesaby/doctree-mcp.git
 cd doctree-mcp
 bun install
-DOCS_ROOT=./docs bun run serve        # stdio
-DOCS_ROOT=./docs bun run serve:http   # HTTP (port 3100)
+
+DOCS_ROOT=./docs bun run serve          # stdio transport
+DOCS_ROOT=./docs bun run serve:http     # HTTP transport (port 3100)
+DOCS_ROOT=./docs bun run index          # CLI: inspect indexed output
 ```
 
-## MCP Tools
-
-### Read tools (always available)
-
-| Tool | Description |
-|------|-------------|
-| `list_documents` | Browse catalog with tag/keyword filtering, facet counts, and cross-reference hints |
-| `search_documents` | BM25 keyword search with facet filters, glossary expansion, and auto-inlined top results |
-| `get_tree` | Hierarchical outline for agent reasoning — structure and word counts, no content |
-| `get_node_content` | Retrieve full text of specific sections by node ID |
-| `navigate_tree` | Get a section and all descendants in one call |
-
-### Wiki curation tools (opt-in: `WIKI_WRITE=1`)
-
-| Tool | Description |
-|------|-------------|
-| `find_similar` | BM25 duplicate detection — checks new content against existing docs before writing |
-| `draft_wiki_entry` | Generates structural scaffold: suggested path, inferred frontmatter, glossary hits, backlinks |
-| `write_wiki_entry` | Validated write with path containment, frontmatter schema checks, and duplicate guards |
-
-## New in This Version
-
-- **Better summaries** — First-sentence extraction instead of raw 200-char truncation
-- **Cross-references** — Markdown links between docs are extracted and exposed to agents
-- **Content facets** — Auto-detected code languages (`code_languages`) and link presence (`has_links`, `has_code`)
-- **Auto-glossary** — Acronym definitions like "TLS (Transport Layer Security)" are automatically extracted from content and used for query expansion
-- **Rich search results** — Top 3 results auto-inline full subtree content with facet badges and resolved cross-references
-- **Wiki curation** — Three new tools for agent-authored documentation with safety guards
-
-## Configuration
-
-### Environment Variables
+## Configuration Reference
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DOCS_ROOT` | `./docs` | Path to markdown repository |
+| `DOCS_ROOT` | `./docs` | Path to your markdown folder |
 | `DOCS_GLOB` | `**/*.md` | File glob pattern |
+| `DOCS_ROOTS` | — | Multiple weighted collections (alternative to `DOCS_ROOT`) |
 | `MAX_DEPTH` | `6` | Max heading depth to index |
 | `SUMMARY_LENGTH` | `200` | Characters in node summaries |
 | `PORT` | `3100` | HTTP server port |
 | `GLOSSARY_PATH` | `$DOCS_ROOT/glossary.json` | Path to abbreviation glossary |
-| `WIKI_WRITE` | *(unset)* | Set to `1` to enable wiki curation tools |
+| `WIKI_WRITE` | *(unset)* | Set to `1` to enable write tools |
 | `WIKI_ROOT` | `$DOCS_ROOT` | Filesystem root for wiki writes |
 | `WIKI_DUPLICATE_THRESHOLD` | `0.35` | Overlap ratio for duplicate warning |
 
-See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for multiple collections, ranking tuning, frontmatter best practices, and glossary setup.
-
-## Using as an LLM Wiki
-
-doctree-mcp supports the [LLM wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — a three-layer architecture where:
-
-1. **Raw sources** (immutable) — your original docs, notes, articles
-2. **The wiki** (LLM-maintained) — markdown files the agent builds and maintains
-3. **The schema** (human-configured) — `CLAUDE.md` or similar files governing structure
-
-See the [LLM Wiki Guide](docs/LLM-WIKI-GUIDE.md) for a complete walkthrough on setting up an LLM-maintained wiki with doctree-mcp.
+Full details: [docs/CONFIGURATION.md](docs/CONFIGURATION.md)
 
 ## Performance
 
-| Operation | Latency | Token cost |
-|-----------|---------|------------|
-| Full index (900 docs) | 2-5s | 0 LLM tokens |
-| Incremental re-index (5 changed) | ~50ms | 0 LLM tokens |
+| Operation | Time | Token cost |
+|-----------|------|------------|
+| Full index (900 docs) | 2-5s | 0 |
+| Incremental re-index | ~50ms | 0 |
 | Search | 5-30ms | ~300-1K tokens |
-| Search with facet filters | 2-15ms | ~200-800 tokens |
 | Tree outline | <1ms | ~200-800 tokens |
 
-Memory: ~25-50MB for 900 docs with full positional index and facets.
+Memory: ~25-50MB for 900 docs with full positional index.
 
 ## Docs
 
-- [Architecture & Design](docs/DESIGN.md) — BM25, tree navigation, Pagefind/PageIndex attribution
-- [Configuration Reference](docs/CONFIGURATION.md) — env vars, frontmatter, ranking tuning, glossary
+- [Architecture & Design](docs/DESIGN.md) — BM25 internals, tree navigation, Pagefind/PageIndex attribution
+- [Configuration](docs/CONFIGURATION.md) — env vars, frontmatter, ranking tuning, glossary
 - [LLM Wiki Guide](docs/LLM-WIKI-GUIDE.md) — setting up an agent-maintained knowledge base
 - [Competitive Analysis](docs/COMPETITIVE-ANALYSIS.md) — comparison with PageIndex, QMD, GitMCP, Context7
 
 ## Standing on Shoulders
 
 - **[PageIndex](https://pageindex.ai)** — Hierarchical tree navigation and the agent reasoning workflow
-- **[Pagefind](https://pagefind.app)** by **[CloudCannon](https://cloudcannon.com)** — BM25 scoring, positional index, filter facets, density excerpts, stemming, and more. Full attribution in [DESIGN.md](docs/DESIGN.md).
-- **[Bun.markdown](https://bun.sh)** by **[Oven](https://oven.sh)** — Native CommonMark parser enabling zero-cost tree construction from raw markdown
+- **[Pagefind](https://pagefind.app)** by **[CloudCannon](https://cloudcannon.com)** — BM25 scoring, positional index, filter facets, density excerpts, stemming
+- **[Bun.markdown](https://bun.sh)** by **[Oven](https://oven.sh)** — Native CommonMark parser for zero-cost tree construction
 - **[Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** — The LLM-maintained wiki pattern that inspired the curation toolset
 
 ## License


### PR DESCRIPTION
Restructure README from a technical reference into a practical guide:
- Lead with "Getting Started" (create docs folder → connect agent → enable writing)
- Organize tools under three phases: Retrieve, Curate, Add
- Add realistic agent conversation examples showing tool chaining
- Surface safety features (path containment, dry-run, duplicate detection)
- Keep reference tables (config, performance, docs links) compact at bottom

https://claude.ai/code/session_01VBMBUj1ByGT9hxScym2fBM