### PR TITLE
Add MCP prompts and Claude Code skills for doc workflows

### DIFF
--- a/.claude/skills/doc-read/SKILL.md
+++ b/.claude/skills/doc-read/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: doc-read
+description: Search and retrieve content from the doctree-mcp knowledge base. Use when you need to find information in the indexed markdown docs.
+argument-hint: [search query or topic]
+---
+
+# Retrieve Documentation
+
+Find and retrieve content from the markdown knowledge base using the doctree-mcp tools.
+
+## Workflow
+
+Follow these steps in order. Do NOT skip the tree step — it lets you target exactly what to read instead of dumping entire documents.
+
+### Step 1: Search or browse
+
+If you have a specific query, search for it:
+
+```
+search_documents(query: "$ARGUMENTS")
+```
+
+If you're exploring broadly or want to see what's available:
+
+```
+list_documents(query: "$ARGUMENTS")
+```
+
+Note the `doc_id` and `node_id` values from the results.
+
+### Step 2: Read the document outline
+
+Pick the most relevant document from step 1 and get its structure:
+
+```
+get_tree(doc_id: "<doc_id from step 1>")
+```
+
+Read the outline carefully. Identify which sections are relevant to the query based on their titles, word counts, and summaries. Do NOT retrieve everything — pick only what matters.
+
+### Step 3: Retrieve specific content
+
+For a single section or a few sections:
+
+```
+get_node_content(doc_id: "<doc_id>", node_ids: ["<node_id>", ...])
+```
+
+For a section and all its subsections (more efficient than fetching each child):
+
+```
+navigate_tree(doc_id: "<doc_id>", node_id: "<parent_node_id>")
+```
+
+### Step 4: Follow cross-references
+
+If the retrieved content mentions or links to other documents, repeat steps 2-3 for those documents if the user needs that information.
+
+## Tips
+
+- **Use specific terms** in search queries — BM25 matches keywords, not semantic meaning
+- **Use facet filters** to narrow search: `filters: { "type": "runbook", "tags": ["auth"] }`
+- **Check search snippets first** — the top 3 results include inline content, which may already answer the question
+- **Prefer `navigate_tree` over multiple `get_node_content` calls** when you need a whole section with children
+- If search returns no results, try alternative terms or check the glossary — abbreviations like "CLI" expand to "command line interface" automatically

--- a/.claude/skills/doc-write/SKILL.md
+++ b/.claude/skills/doc-write/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: doc-write
+description: Create a new wiki entry in the doctree-mcp knowledge base. Checks for duplicates, generates a scaffold, and writes with validation. Requires WIKI_WRITE=1.
+argument-hint: [topic or title for the new entry]
+---
+
+# Write Documentation
+
+Create a new markdown document in the knowledge base using the doctree-mcp wiki curation tools.
+
+**Requires `WIKI_WRITE=1` in the MCP server configuration.** If the write tools are unavailable, tell the user to add `"WIKI_WRITE": "1"` to their doctree env config.
+
+## Workflow
+
+Follow these steps in order. Do NOT skip the duplicate check — it prevents content sprawl.
+
+### Step 1: Check for duplicates
+
+Before writing anything, check if similar content already exists:
+
+```
+find_similar(content: "<the content you plan to write>")
+```
+
+If matches are found with overlap > 0.35:
+- **Read the existing doc** using the doc-read workflow (search → tree → content)
+- **Decide**: update the existing doc, or confirm with the user that a new doc is warranted
+- If the user wants to proceed anyway, you'll use `allow_duplicate: true` in step 4
+
+### Step 2: Generate a scaffold
+
+Get suggestions for path, frontmatter, and structure:
+
+```
+draft_wiki_entry(
+  topic: "$ARGUMENTS",
+  raw_content: "<the content to turn into a wiki entry>"
+)
+```
+
+Review what comes back:
+- **Suggested path** — adjust if needed (e.g., put runbooks in `runbooks/`, guides in `guides/`)
+- **Inferred frontmatter** — type, category, tags derived from similar docs
+- **Glossary hits** — acronyms detected in the content
+- **Duplicate warnings** — similar docs that might overlap
+
+### Step 3: Dry-run validation
+
+Validate the entry without writing to disk:
+
+```
+write_wiki_entry(
+  path: "<path from step 2, adjusted if needed>",
+  frontmatter: {
+    "title": "<title>",
+    "description": "<one-line summary>",
+    "type": "<runbook|guide|reference|tutorial|architecture|adr|...>",
+    "category": "<domain grouping>",
+    "tags": ["<relevant>", "<terms>"]
+  },
+  content: "<full markdown content>",
+  dry_run: true
+)
+```
+
+Check the result for warnings. Fix any issues before proceeding.
+
+### Step 4: Write the entry
+
+Once validation passes, write for real:
+
+```
+write_wiki_entry(
+  path: "<same path>",
+  frontmatter: { ... },
+  content: "<full markdown content>",
+  dry_run: false
+)
+```
+
+Report the resulting `doc_id` and path to the user.
+
+## Frontmatter Guidelines
+
+Always include these fields:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `title` | Yes | Descriptive, avoid generic names like "Introduction" |
+| `description` | Yes | One-line summary, used for search ranking |
+| `type` | Yes | `runbook`, `guide`, `reference`, `tutorial`, `architecture`, `adr`, `procedure`, etc. |
+| `tags` | Yes | 3-8 relevant terms for discoverability |
+| `category` | Recommended | Domain grouping (e.g., `auth`, `deploy`, `monitoring`) |
+
+## Tips
+
+- **Define acronyms inline** on first use — e.g., "TLS (Transport Layer Security)" — doctree-mcp auto-extracts these into the glossary
+- **Use meaningful directory paths** — `runbooks/deploy.md` auto-infers `type: runbook`
+- **Link to related docs** with standard markdown links — doctree-mcp extracts these as cross-references
+- **Keep one topic per file** — smaller, focused docs score better in search than long monoliths
+- **Use heading hierarchy** (H1 → H2 → H3) — each heading becomes a navigable tree node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ src/
 ├── store.ts            # In-memory BM25 search engine + filter facets + glossary + ref map
 ├── types.ts            # All TypeScript interfaces and ranking defaults
 ├── tools.ts            # MCP tool registrations (shared by stdio + HTTP servers)
+├── prompts.ts          # MCP prompt templates: doc-read + doc-write workflows (all clients)
 ├── search-formatter.ts # Rich search result formatting with inline content + facet badges
 ├── curator.ts          # Wiki curation: findSimilar, draftWikiEntry, writeWikiEntry
 ├── server.ts           # MCP stdio server entry point

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ To let your agent create and update docs, add `WIKI_WRITE`:
 
 This unlocks 3 additional wiki curation tools with safety guards: path containment, frontmatter validation, and duplicate detection.
 
+### 4. Use the built-in workflow prompts
+
+doctree-mcp registers two **MCP prompts** that guide any agent through the correct tool workflow. These work with every MCP client — Claude Desktop, Claude Code, Cursor, Windsurf, or any tool that supports the MCP protocol.
+
+| Prompt | What it does |
+|--------|-------------|
+| `doc-read` | Search → browse outline → retrieve specific sections |
+| `doc-write` | Check duplicates → scaffold → validate → write |
+
+Your agent can invoke these prompts to get step-by-step instructions for using the tools in the right order. No need to memorize the tool chain — the prompts encode it.
+
+> **Claude Code bonus:** The same workflows are also available as slash commands (`/doc-read`, `/doc-write`) via the `.claude/skills/` directory included in this repo.
+
 ---
 
 ## How It Works: Retrieve, Curate, Add
@@ -353,6 +366,8 @@ Memory: ~25-50MB for 900 docs with full positional index.
 - [Configuration](docs/CONFIGURATION.md) — env vars, frontmatter, ranking tuning, glossary
 - [LLM Wiki Guide](docs/LLM-WIKI-GUIDE.md) — setting up an agent-maintained knowledge base
 - [Competitive Analysis](docs/COMPETITIVE-ANALYSIS.md) — comparison with PageIndex, QMD, GitMCP, Context7
+- [Prompts source](src/prompts.ts) — MCP prompt templates (work with all clients)
+- [Skills: `/doc-read`](.claude/skills/doc-read/SKILL.md), [`/doc-write`](.claude/skills/doc-write/SKILL.md) — Claude Code slash commands
 
 ## Standing on Shoulders
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,141 @@
+/**
+ * MCP Prompt registrations for doctree-mcp.
+ *
+ * Prompts are workflow templates discoverable by ANY MCP client
+ * (Claude Desktop, Cursor, Windsurf, etc.) — not just Claude Code.
+ * They guide agents through the correct tool-chaining patterns for
+ * reading and writing documentation.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export function registerPrompts(
+  server: McpServer,
+  options?: { wikiEnabled?: boolean }
+): void {
+  // ── Prompt 1: doc-read ──────────────────────────────────────────────
+  server.registerPrompt("doc-read", {
+    title: "Read Documentation",
+    description:
+      "Search and retrieve content from the knowledge base. Guides the agent through: search → browse outline → retrieve specific sections.",
+    argsSchema: {
+      query: z
+        .string()
+        .describe("Search query or topic to find in the documentation"),
+    },
+  }, ({ query }) => ({
+    messages: [
+      {
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: [
+            `Find information about: ${query}`,
+            "",
+            "Follow this workflow using the doctree-mcp tools:",
+            "",
+            "## Step 1: Search",
+            `Call search_documents with query: "${query}"`,
+            "Note the doc_id and node_id values from the results.",
+            "If no results, try alternative terms — abbreviations like \"CLI\" auto-expand to \"command line interface\" via the glossary.",
+            "You can narrow results with facet filters, e.g.: filters: { \"type\": \"runbook\", \"tags\": [\"auth\"] }",
+            "",
+            "## Step 2: Browse the outline",
+            "Pick the most relevant document and call get_tree with its doc_id.",
+            "Read the heading hierarchy to identify which sections are relevant.",
+            "Do NOT retrieve everything — pick only what matters based on titles, word counts, and summaries.",
+            "",
+            "## Step 3: Retrieve specific content",
+            "For a section and all its subsections, use navigate_tree(doc_id, node_id) — this is most efficient.",
+            "For a few individual sections, use get_node_content(doc_id, [node_id, ...]) — up to 10 at once.",
+            "",
+            "## Step 4: Follow cross-references",
+            "If the content links to other documents, repeat steps 2-3 for those if relevant.",
+          ].join("\n"),
+        },
+      },
+    ],
+  }));
+
+  // ── Prompt 2: doc-write ─────────────────────────────────────────────
+  server.registerPrompt("doc-write", {
+    title: "Write Documentation",
+    description:
+      "Create a new wiki entry with duplicate checking, scaffold generation, and validated writing. Requires WIKI_WRITE=1.",
+    argsSchema: {
+      topic: z
+        .string()
+        .describe("Topic or title for the new documentation entry"),
+    },
+  }, ({ topic }) => {
+    if (!options?.wikiEnabled) {
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: [
+                `Write documentation about: ${topic}`,
+                "",
+                "**Wiki write tools are not enabled.** To use this workflow, the MCP server must be configured with WIKI_WRITE=1.",
+                "",
+                "Add this to your MCP configuration:",
+                '  "env": { "DOCS_ROOT": "./docs", "WIKI_WRITE": "1" }',
+              ].join("\n"),
+            },
+          },
+        ],
+      };
+    }
+
+    return {
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: [
+              `Create a new wiki entry about: ${topic}`,
+              "",
+              "Follow this workflow using the doctree-mcp tools:",
+              "",
+              "## Step 1: Check for duplicates",
+              "Call find_similar with the content you plan to write.",
+              "If matches are found with overlap > 0.35:",
+              "- Read the existing doc (search → get_tree → get_node_content)",
+              "- Decide whether to update the existing doc or confirm a new one is warranted",
+              "",
+              "## Step 2: Generate a scaffold",
+              `Call draft_wiki_entry with topic: "${topic}" and your raw_content.`,
+              "Review the result:",
+              "- Suggested path — adjust if needed (e.g., put runbooks in runbooks/, guides in guides/)",
+              "- Inferred frontmatter — type, category, tags from similar docs",
+              "- Glossary hits — acronyms detected in the content",
+              "",
+              "## Step 3: Dry-run validation",
+              "Call write_wiki_entry with dry_run: true to validate without writing to disk.",
+              "Include complete frontmatter:",
+              "- title: Descriptive title (avoid generic names like \"Introduction\")",
+              "- description: One-line summary for search ranking",
+              "- type: runbook | guide | reference | tutorial | architecture | adr | procedure",
+              "- tags: 3-8 relevant terms for discoverability",
+              "- category: Domain grouping (e.g., auth, deploy, monitoring)",
+              "",
+              "## Step 4: Write the entry",
+              "If validation passes, call write_wiki_entry with dry_run: false.",
+              "Report the resulting doc_id and path.",
+              "",
+              "## Writing tips",
+              "- Define acronyms inline on first use, e.g., \"TLS (Transport Layer Security)\" — these are auto-extracted into the glossary",
+              "- Use heading hierarchy (H1 → H2 → H3) — each heading becomes a navigable tree node",
+              "- Link to related docs with markdown links — doctree-mcp extracts these as cross-references",
+              "- Keep one topic per file — smaller docs score better in search",
+            ].join("\n"),
+          },
+        },
+      ],
+    };
+  });
+}

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -17,6 +17,7 @@ import { singleRootConfig } from "./types";
 import type { IndexConfig } from "./types";
 import type { WikiOptions } from "./curator";
 import { registerTools } from "./tools";
+import { registerPrompts } from "./prompts";
 
 const docs_root = process.env.DOCS_ROOT || "./docs";
 const config: IndexConfig = singleRootConfig(docs_root);
@@ -108,6 +109,7 @@ function createMcpServer(store: DocumentStore, wiki?: WikiOptions): McpServer {
   });
 
   registerTools(server, store, { wiki });
+  registerPrompts(server, { wikiEnabled: !!wiki });
 
   return server;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { singleRootConfig } from "./types";
 import type { IndexConfig } from "./types";
 import type { WikiOptions } from "./curator";
 import { registerTools } from "./tools";
+import { registerPrompts } from "./prompts";
 
 // ── Configuration ────────────────────────────────────────────────────
 
@@ -67,6 +68,7 @@ if (process.env.WIKI_WRITE === "1") {
 // ── Register tools ──────────────────────────────────────────────────
 
 registerTools(server, store, { wiki });
+registerPrompts(server, { wikiEnabled: !!wiki });
 
 // ── Resources: expose index stats ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **MCP prompts** (`doc-read`, `doc-write`) registered via `server.registerPrompt()` — discoverable by ALL MCP clients (Claude Desktop, Cursor, Windsurf, any MCP-compatible tool)
- **Claude Code skills** (`.claude/skills/doc-read/`, `.claude/skills/doc-write/`) as bonus slash commands for Claude Code users
- **README updated** with Getting Started step 4 explaining the workflow prompts and docs links

### `doc-read` prompt
Guides the agent through: `search_documents` → `get_tree` → `navigate_tree`/`get_node_content` → follow cross-references

### `doc-write` prompt
Guides the agent through: `find_similar` → `draft_wiki_entry` → `write_wiki_entry` (dry_run) → `write_wiki_entry` (real). Returns a clear message if `WIKI_WRITE` is not enabled.

### Why MCP prompts instead of just skills?
Claude Code skills (`.claude/skills/`) only work in Claude Code. MCP prompts are part of the protocol itself — any MCP client can discover and use them. This ensures agents using Claude Desktop, Cursor, Windsurf, or custom MCP clients all get the same workflow guidance.

## Test plan

- [x] `bun test` — 143 tests pass, no regressions
- [ ] Verify `doc-read` prompt appears in MCP client prompt listing
- [ ] Verify `doc-write` prompt returns wiki-disabled message when `WIKI_WRITE` is unset
- [ ] Verify `/doc-read` and `/doc-write` slash commands work in Claude Code

https://claude.ai/code/session_01VBMBUj1ByGT9hxScym2fBM