### PR TITLE
Bump to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doctree-mcp",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "mcpName": "io.github.joesaby/doctree-mcp",
   "description": "Agentic document retrieval over markdown — BM25 search + tree navigation via MCP. Inspired by PageIndex and Pagefind.",
   "type": "module",


### PR DESCRIPTION
Version bump for the 1.1.0 release.

## What's in 1.1.0

- **`bunx doctree-mcp-init`** — new CLI to scaffold the Karpathy three-layer wiki structure and configure MCP + lint hooks for Claude Code, Cursor, Windsurf, Codex CLI, and OpenCode
- **`bunx doctree-mcp-lint`** — new CLI for wiki health checks (orphans, stubs, missing frontmatter, broken links); auto-runs after `write_wiki_entry` via post-write hooks
- **Rich tool output** — `find_similar` and `draft_wiki_entry` return formatted text instead of raw JSON
- **Update workflow** — `doc-write` prompt and skill now have an explicit overlap > 0.35 branch: read → merge → `write_wiki_entry(overwrite: true)`
- **New `doc-lint` MCP prompt** — guides agents through wiki health audits
- **New `/doc-lint` Claude Code skill**
- **README rewrite** — dual quick-start paths + per-tool setup guide for 6 tools
- **LLM-WIKI-GUIDE refresh** — init-first, update pattern, lint pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)