### PR TITLE
fix: bunx doctree-mcp init/lint subcommands

### DIFF
--- a/.claude/skills/doc-lint/SKILL.md
+++ b/.claude/skills/doc-lint/SKILL.md
@@ -37,6 +37,6 @@ Ask the user whether to fix each issue now, or skip.
 
 ## Tips
 
-- Run `bunx doctree-mcp-lint` in the terminal for a quick machine-readable summary
+- Run `bunx doctree-mcp lint` in the terminal for a quick machine-readable summary
 - Use `find_similar` if you want to check whether a stub should be merged into another doc
 - Cross-references are markdown links — adding `[Auth Guide](../auth/guide.md)` to a doc removes its orphan status

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ doctree-mcp is an [MCP](https://modelcontextprotocol.io/) server that indexes yo
 Run the init command in your project root:
 
 ```bash
-bunx doctree-mcp-init
+bunx doctree-mcp init
 ```
 
 This scaffolds the [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) three-layer structure and configures your AI tool(s) automatically:
@@ -30,8 +30,8 @@ This scaffolds the [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf5
 - Appends wiki conventions to `CLAUDE.md` / `AGENTS.md` / `.cursor/rules/`
 
 ```bash
-bunx doctree-mcp-init --all     # configure all supported tools
-bunx doctree-mcp-init --dry-run # preview without writing
+bunx doctree-mcp init --all     # configure all supported tools
+bunx doctree-mcp init --dry-run # preview without writing
 ```
 
 See [docs/LLM-WIKI-GUIDE.md](docs/LLM-WIKI-GUIDE.md) for the full walkthrough.
@@ -71,7 +71,7 @@ Add `.mcp.json` to your project root:
     "PostToolUse": [
       {
         "matcher": "write_wiki_entry",
-        "hooks": [{ "type": "command", "command": "bunx doctree-mcp-lint" }]
+        "hooks": [{ "type": "command", "command": "bunx doctree-mcp lint" }]
       }
     ]
   }
@@ -107,12 +107,12 @@ Add `.cursor/mcp.json` to your project root:
 {
   "version": 1,
   "hooks": {
-    "afterMCPExecution": [{ "command": "bunx doctree-mcp-lint" }]
+    "afterMCPExecution": [{ "command": "bunx doctree-mcp lint" }]
   }
 }
 ```
 
-**Rules** — commit `.cursor/rules/doctree-wiki.mdc` with your wiki conventions (created by `bunx doctree-mcp-init`).
+**Rules** — commit `.cursor/rules/doctree-wiki.mdc` with your wiki conventions (created by `bunx doctree-mcp init`).
 
 ---
 
@@ -142,7 +142,7 @@ Add `.windsurf/mcp.json` to your project root:
 ```json
 {
   "hooks": {
-    "post_mcp_tool_use": [{ "command": "bunx doctree-mcp-lint" }]
+    "post_mcp_tool_use": [{ "command": "bunx doctree-mcp lint" }]
   }
 }
 ```
@@ -165,7 +165,7 @@ WIKI_WRITE = "1"
 
 **Workflow prompts:** Use the `doc-read`, `doc-write`, and `doc-lint` MCP prompts.
 
-**Lint hook:** Codex hooks currently only intercept Bash tool calls. MCP tool interception is not yet supported — run `bunx doctree-mcp-lint` manually or use the `doc-lint` prompt for audits.
+**Lint hook:** Codex hooks currently only intercept Bash tool calls. MCP tool interception is not yet supported — run `bunx doctree-mcp lint` manually or use the `doc-lint` prompt for audits.
 
 ---
 
@@ -192,13 +192,13 @@ Add to `opencode.json`:
 
 **Workflow prompts:** Use the `doc-read`, `doc-write`, and `doc-lint` MCP prompts.
 
-**Lint plugin** — add `.opencode/plugins/doctree-lint.js` (created by `bunx doctree-mcp-init`):
+**Lint plugin** — add `.opencode/plugins/doctree-lint.js` (created by `bunx doctree-mcp init`):
 
 ```javascript
 export const DoctreeLintPlugin = async ({ $ }) => ({
   "tool.execute.after": async (event) => {
     if (event?.tool?.name === "write_wiki_entry") {
-      try { await $`bunx doctree-mcp-lint`; } catch {}
+      try { await $`bunx doctree-mcp lint`; } catch {}
     }
   },
 });
@@ -224,7 +224,7 @@ Add to your [Claude Desktop config](https://modelcontextprotocol.io/quickstart/u
 }
 ```
 
-> Claude Desktop does not support project-level hook configs. Use `bunx doctree-mcp-lint` manually or invoke the `doc-lint` MCP prompt for audits.
+> Claude Desktop does not support project-level hook configs. Use `bunx doctree-mcp lint` manually or invoke the `doc-lint` MCP prompt for audits.
 
 ---
 

--- a/bin.ts
+++ b/bin.ts
@@ -1,2 +1,12 @@
 #!/usr/bin/env -S bun run
-import './src/server.ts'
+const sub = Bun.argv[2];
+
+if (sub === "init") {
+  const { main } = await import('./src/cli-init.ts');
+  await main();
+} else if (sub === "lint") {
+  const { main } = await import('./src/cli-lint.ts');
+  await main();
+} else {
+  await import('./src/server.ts');
+}

--- a/docs/LLM-WIKI-GUIDE.md
+++ b/docs/LLM-WIKI-GUIDE.md
@@ -21,7 +21,7 @@ This implements the three-layer architecture from [Andrej Karpathy's LLM wiki pa
 Run in your project root:
 
 ```bash
-bunx doctree-mcp-init
+bunx doctree-mcp init
 ```
 
 This creates the three-layer structure and configures your AI tool:
@@ -123,14 +123,14 @@ The `doc-lint` prompt guides the agent through: orphan detection → stub detect
 Run the linter manually at any time:
 
 ```bash
-WIKI_ROOT=./docs/wiki bunx doctree-mcp-lint
+WIKI_ROOT=./docs/wiki bunx doctree-mcp lint
 ```
 
 ---
 
 ## Step 5: Multi-collection search
 
-By default, `bunx doctree-mcp-init` configures two collections with different weights:
+By default, `bunx doctree-mcp init` configures two collections with different weights:
 
 ```
 DOCS_ROOTS=./docs/wiki:1.0,./docs/raw-sources:0.3

--- a/src/cli-init.ts
+++ b/src/cli-init.ts
@@ -2,9 +2,9 @@
  * Init CLI — scaffolds a Karpathy-style LLM wiki and configures AI tools.
  *
  * Usage:
- *   bunx doctree-mcp-init           # interactive tool selection
- *   bunx doctree-mcp-init --all     # configure all supported tools
- *   bunx doctree-mcp-init --dry-run # print actions without writing
+ *   bunx doctree-mcp init           # interactive tool selection
+ *   bunx doctree-mcp init --all     # configure all supported tools
+ *   bunx doctree-mcp init --dry-run # print actions without writing
  */
 
 import { resolve, join, dirname } from "node:path";
@@ -170,7 +170,7 @@ export function generateHookConfig(tool: Tool): GeneratedFile | null {
               PostToolUse: [
                 {
                   matcher: "write_wiki_entry",
-                  hooks: [{ type: "command", command: "bunx doctree-mcp-lint" }],
+                  hooks: [{ type: "command", command: "bunx doctree-mcp lint" }],
                 },
               ],
             },
@@ -187,7 +187,7 @@ export function generateHookConfig(tool: Tool): GeneratedFile | null {
           {
             version: 1,
             hooks: {
-              afterMCPExecution: [{ command: "bunx doctree-mcp-lint" }],
+              afterMCPExecution: [{ command: "bunx doctree-mcp lint" }],
             },
           },
           null,
@@ -203,7 +203,7 @@ export function generateHookConfig(tool: Tool): GeneratedFile | null {
             hooks: {
               // Windsurf cannot filter by MCP tool name — runs on all MCP calls.
               // doctree-mcp-lint exits quickly when there are no issues.
-              post_mcp_tool_use: [{ command: "bunx doctree-mcp-lint" }],
+              post_mcp_tool_use: [{ command: "bunx doctree-mcp lint" }],
             },
           },
           null,
@@ -219,7 +219,7 @@ export function generateHookConfig(tool: Tool): GeneratedFile | null {
           "export const DoctreeLintPlugin = async ({ $ }) => ({",
           '  "tool.execute.after": async (event) => {',
           '    if (event?.tool?.name === "write_wiki_entry") {',
-          "      try { await $`bunx doctree-mcp-lint`; } catch {}",
+          "      try { await $`bunx doctree-mcp lint`; } catch {}",
           "    }",
           "  },",
           "});",
@@ -241,7 +241,7 @@ export function generateHookConfig(tool: Tool): GeneratedFile | null {
                     {
                       type: "command",
                       command:
-                        "# Codex MCP hooks not yet supported. Remove this comment when available.\n# bunx doctree-mcp-lint",
+                        "# Codex MCP hooks not yet supported. Remove this comment when available.\n# bunx doctree-mcp lint",
                     },
                   ],
                 },

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -96,7 +96,7 @@ describe("generateHookConfig", () => {
     const postHooks = parsed.hooks?.PostToolUse;
     expect(postHooks).toBeDefined();
     expect(postHooks[0].matcher).toBe("write_wiki_entry");
-    expect(postHooks[0].hooks[0].command).toContain("doctree-mcp-lint");
+    expect(postHooks[0].hooks[0].command).toContain("doctree-mcp lint");
   });
 
   test("cursor: afterMCPExecution event", () => {
@@ -120,7 +120,7 @@ describe("generateHookConfig", () => {
     expect(result!.path).toBe(".opencode/plugins/doctree-lint.js");
     expect(result!.content).toContain("tool.execute.after");
     expect(result!.content).toContain("write_wiki_entry");
-    expect(result!.content).toContain("doctree-mcp-lint");
+    expect(result!.content).toContain("doctree-mcp lint");
   });
 
   test("codex: PostToolUse present", () => {


### PR DESCRIPTION
## Problem

`bunx doctree-mcp-init` fails with 404 because `bunx` looks up a package by that exact name on npm. The package is `doctree-mcp`, not `doctree-mcp-init`.

## Fix

- `bin.ts` now dispatches subcommands: `bunx doctree-mcp init` and `bunx doctree-mcp lint`
- Updated all docs, hook config templates in `cli-init.ts`, and test expectations to use the new command names
- All 191 tests pass

## New usage

```bash
bunx doctree-mcp init           # was: bunx doctree-mcp-init
bunx doctree-mcp init --all
bunx doctree-mcp init --dry-run
bunx doctree-mcp lint           # was: bunx doctree-mcp-lint
bunx doctree-mcp                # unchanged — starts MCP server
```

The `bin-init.ts` / `bin-lint.ts` wrappers and their `package.json` bin entries are kept for users who install the package globally (`bun add -g doctree-mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)