### PR TITLE
Bump to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doctree-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "mcpName": "io.github.joesaby/doctree-mcp",
   "description": "Agentic document retrieval over markdown — BM25 search + tree navigation via MCP. Inspired by PageIndex and Pagefind.",
   "type": "module",


### PR DESCRIPTION
Patch release fixing `bunx` invocation.

## What's fixed

- `bunx doctree-mcp init` and `bunx doctree-mcp lint` now work correctly — `bunx doctree-mcp-init` was returning 404 because bunx resolves package names, not binary names
- `bin.ts` dispatches `init` and `lint` subcommands to the respective CLIs
- All docs and generated hook configs updated to use the correct command names

🤖 Generated with [Claude Code](https://claude.com/claude-code)