### PR TITLE
docs: frame skill + MCP pattern; split README into focused guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,309 +1,87 @@
 # doctree-mcp
 
-Give your AI agent a markdown knowledge base it can search, browse, and write to — no vector DB, no embeddings, no LLM calls at index time.
+**Agentic document retrieval over markdown, CSV, and JSONL.** BM25 + tree navigation via [MCP](https://modelcontextprotocol.io/) — no vector DB, no embeddings, no LLM calls at index time.
 
-doctree-mcp is an [MCP](https://modelcontextprotocol.io/) server that indexes your markdown, CSV, and JSONL files and exposes them as structured tools. Your agent gets BM25 search, a navigable table of contents, exact key-based row lookup for structured data, and (optionally) the ability to write and maintain docs.
-
-**The pitch in one line:** MCP provides the structural primitives (a navigable tree + BM25 + glossary), the included skills provide the procedural knowledge (how to walk the tree), and together the agent behaves like a trained research librarian — not a one-shot searcher. See [The Skill + MCP Pattern](#the-skill--mcp-pattern).
+**The pitch:** MCP provides the structural primitives (a navigable tree, BM25, glossary, row lookup). The bundled skills provide the procedural knowledge (how to walk that tree). Together the agent behaves like a trained research librarian — not a one-shot searcher. See [The Skill + MCP Pattern](#the-skill--mcp-pattern).
 
 ---
 
 ## Quick Start
 
-### Already have docs?
-
-1. Point `DOCS_ROOT` at your markdown folder in your AI tool's MCP config (see [Setup by AI Tool](#setup-by-ai-tool) below)
-2. Restart your AI tool
-3. Ask your agent: *"Search the docs for X"* or use the `doc-read` MCP prompt
-
-### Starting fresh? (LLM Wiki)
-
-Run the init command in your project root:
+**Have docs already?** Point a client at them:
 
 ```bash
-bunx doctree-mcp init
+# In your AI tool's MCP config — see docs/CLIENTS.md for per-tool snippets
+{ "mcpServers": { "doctree": {
+    "command": "bunx", "args": ["doctree-mcp"],
+    "env": { "DOCS_ROOT": "./docs", "WIKI_WRITE": "1" }
+} } }
 ```
 
-This scaffolds the [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) three-layer structure and configures your AI tool(s) automatically:
+Restart the tool → ask *"search the docs for X"* or invoke the `doc-read` prompt.
 
-- Creates `docs/wiki/` (LLM-maintained) and `docs/raw-sources/` (your inputs)
-- Writes MCP config for your selected AI tool(s)
-- Installs a post-write lint hook so your agent gets health warnings automatically
-- Appends wiki conventions to `CLAUDE.md` / `AGENTS.md` / `.cursor/rules/`
+**Starting fresh?** Scaffold a Karpathy-style [LLM wiki](./docs/LLM-WIKI-GUIDE.md):
 
 ```bash
-bunx doctree-mcp init --all     # configure all supported tools
-bunx doctree-mcp init --dry-run # preview without writing
+bunx doctree-mcp init          # configure current tool
+bunx doctree-mcp init --all    # configure every supported client
+bunx doctree-mcp init --dry-run
 ```
 
-See [docs/LLM-WIKI-GUIDE.md](docs/LLM-WIKI-GUIDE.md) for the full walkthrough.
+Creates `docs/wiki/` (LLM-maintained) + `docs/raw-sources/` (your inputs), writes the MCP config, installs a post-write lint hook, appends wiki conventions to `CLAUDE.md` / `AGENTS.md` / `.cursor/rules/`.
 
 ---
 
-## Setup by AI Tool
+## Operation Modes
 
-All tools use the same MCP server. Replace `./docs` with your actual docs path.
+| Mode | Use when | Guide |
+|---|---|---|
+| **stdio** (default) | Local dev, agent on your machine | [Client setup](./docs/CLIENTS.md) |
+| **HTTP** (Streamable HTTP) | Teams, CI, hosted agents | [Deployment](./docs/DEPLOY.md) — Railway · Fly · Render · Cloudflare Containers · Docker |
+| **CLI** | `init`, `lint`, debug-index | [Operation modes](./docs/OPERATION-MODES.md#cli-mode) |
 
-### Claude Code
-
-Add `.mcp.json` to your project root:
-
-```json
-{
-  "mcpServers": {
-    "doctree": {
-      "command": "bunx",
-      "args": ["doctree-mcp"],
-      "env": {
-        "DOCS_ROOT": "./docs",
-        "WIKI_WRITE": "1"
-      }
-    }
-  }
-}
-```
-
-**Workflow prompts:** Use `/doc-read`, `/doc-write`, `/doc-lint` slash commands (skills included in this repo).
-
-**Lint hook** — add to `.claude/settings.json` to get health warnings after every write:
-
-```json
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "write_wiki_entry",
-        "hooks": [{ "type": "command", "command": "bunx doctree-mcp lint" }]
-      }
-    ]
-  }
-}
-```
+Full decision tree: [Operation Modes](./docs/OPERATION-MODES.md).
 
 ---
 
-### Cursor
-
-Add `.cursor/mcp.json` to your project root:
-
-```json
-{
-  "mcpServers": {
-    "doctree": {
-      "command": "bunx",
-      "args": ["doctree-mcp"],
-      "env": {
-        "DOCS_ROOT": "./docs",
-        "WIKI_WRITE": "1"
-      }
-    }
-  }
-}
-```
-
-**Workflow prompts:** Use the `doc-read`, `doc-write`, and `doc-lint` MCP prompts from the chat panel.
-
-**Lint hook** — add to `.cursor/hooks.json`:
-
-```json
-{
-  "version": 1,
-  "hooks": {
-    "afterMCPExecution": [{ "command": "bunx doctree-mcp lint" }]
-  }
-}
-```
-
-**Rules** — commit `.cursor/rules/doctree-wiki.mdc` with your wiki conventions (created by `bunx doctree-mcp init`).
-
----
-
-### Windsurf
-
-Add `.windsurf/mcp.json` to your project root:
-
-```json
-{
-  "mcpServers": {
-    "doctree": {
-      "command": "bunx",
-      "args": ["doctree-mcp"],
-      "env": {
-        "DOCS_ROOT": "./docs",
-        "WIKI_WRITE": "1"
-      }
-    }
-  }
-}
-```
-
-**Workflow prompts:** Use the `doc-read`, `doc-write`, and `doc-lint` MCP prompts from Cascade.
-
-**Lint hook** — add to `.windsurf/hooks.json` (runs after all MCP calls — fast and safe):
-
-```json
-{
-  "hooks": {
-    "post_mcp_tool_use": [{ "command": "bunx doctree-mcp lint" }]
-  }
-}
-```
-
----
-
-### Codex CLI
-
-Add to `.codex/config.toml`:
-
-```toml
-[mcp_servers.doctree]
-command = "bunx"
-args = ["doctree-mcp"]
-
-[mcp_servers.doctree.env]
-DOCS_ROOT = "./docs"
-WIKI_WRITE = "1"
-```
-
-**Workflow prompts:** Use the `doc-read`, `doc-write`, and `doc-lint` MCP prompts.
-
-**Lint hook:** Codex hooks currently only intercept Bash tool calls. MCP tool interception is not yet supported — run `bunx doctree-mcp lint` manually or use the `doc-lint` prompt for audits.
-
----
-
-### OpenCode
-
-Add to `opencode.json`:
-
-```json
-{
-  "mcp": {
-    "servers": {
-      "doctree": {
-        "command": "bunx",
-        "args": ["doctree-mcp"],
-        "env": {
-          "DOCS_ROOT": "./docs",
-          "WIKI_WRITE": "1"
-        }
-      }
-    }
-  }
-}
-```
-
-**Workflow prompts:** Use the `doc-read`, `doc-write`, and `doc-lint` MCP prompts.
-
-**Lint plugin** — add `.opencode/plugins/doctree-lint.js` (created by `bunx doctree-mcp init`):
-
-```javascript
-export const DoctreeLintPlugin = async ({ $ }) => ({
-  "tool.execute.after": async (event) => {
-    if (event?.tool?.name === "write_wiki_entry") {
-      try { await $`bunx doctree-mcp lint`; } catch {}
-    }
-  },
-});
-```
-
----
-
-### Claude Desktop
-
-Add to your [Claude Desktop config](https://modelcontextprotocol.io/quickstart/user):
-
-```json
-{
-  "mcpServers": {
-    "doctree": {
-      "command": "bunx",
-      "args": ["doctree-mcp"],
-      "env": {
-        "DOCS_ROOT": "/absolute/path/to/your/docs"
-      }
-    }
-  }
-}
-```
-
-> Claude Desktop does not support project-level hook configs. Use `bunx doctree-mcp lint` manually or invoke the `doc-lint` MCP prompt for audits.
-
----
-
-## How It Works: Retrieve · Curate · Add
-
-### Retrieve
+## How It Works — Retrieve · Curate · Add
 
 ```
-Agent: I need to understand the token refresh flow.
+Agent: "How does token refresh work?"
 
 → search_documents("token refresh")
   #1  auth/middleware.md § Token Refresh Flow       score: 12.4
-  #2  auth/oauth.md § Refresh Token Lifecycle       score: 8.7
+  #2  auth/oauth.md       § Refresh Token Lifecycle  score: 8.7
 
 → get_tree("docs:auth:middleware")
-  [n1] # Auth Middleware (450 words)
-    [n4] ## Token Refresh Flow (180 words)
-      [n5] ### Automatic Refresh (90 words)
+  [n1] # Auth Middleware
+    [n4] ## Token Refresh Flow
+      [n5] ### Automatic Refresh
 
-→ navigate_tree("docs:auth:middleware", "n4")
-  Returns n4 + n5 — the full section and all subsections.
+→ navigate_tree("docs:auth:middleware", "n4")   ← n4 + descendants
 ```
 
-**5 core retrieval tools:**
+**Core read tools** (always on):
 
-| Tool | What it does |
-|------|-------------|
-| `search_documents` | BM25 keyword search with facet filters and glossary expansion. Works across markdown, CSV, and JSONL. |
-| `get_tree` | Table of contents — headings, word counts, summaries. |
-| `get_node_content` | Full text of specific sections by node ID. |
-| `navigate_tree` | A section and all its descendants in one call. |
-| `lookup_row` | O(1) exact key lookup for structured data rows (e.g. `PROJ-44`). See [Structured Data](#structured-data). |
+| Tool | Purpose |
+|---|---|
+| `search_documents` | BM25 keyword search + facet filters + glossary expansion (markdown · CSV · JSONL) |
+| `get_tree` | Table of contents — headings, word counts, summaries |
+| `get_node_content` | Full text of a specific section by node ID |
+| `navigate_tree` | A section plus all descendants in one call |
+| `lookup_row` | O(1) exact-key lookup for structured data rows (e.g. `PROJ-44`) |
 
-**Deprecated retrieval tools** (still functional, superseded by core tools):
+**Wiki write tools** (opt-in with `WIKI_WRITE=1`):
 
-| Tool | Replacement |
-|------|-------------|
-| `list_documents` | `search_documents` with filters |
-| `find_files` | `search_documents` finds content by meaning, not path |
-| `find_symbol` | `search_documents` already boosts title matches at 3x |
+| Tool | Purpose |
+|---|---|
+| `find_similar` | Duplicate detection with overlap ratios |
+| `draft_wiki_entry` | Scaffold: suggested path, inferred frontmatter, glossary hits |
+| `write_wiki_entry` | Validated write: path containment, schema, duplicate guards, dry-run |
 
-### Curate
+Safety: path containment · frontmatter validation · duplicate detection · dry-run · overwrite protection.
 
-```
-→ find_similar("JWT validation middleware checks the token signature...")
-  [overlap: 0.42] docs:auth:middleware — Auth Middleware
-    ⚠ Consider updating this doc instead of creating a new one.
-    → navigate_tree("docs:auth:middleware", "<root_node_id>") to read it
-
-→ navigate_tree("docs:auth:middleware", "n1")   ← read existing doc
-→ write_wiki_entry(path: "auth/middleware.md", ..., overwrite: true)  ← merge + update
-```
-
-### Add
-
-```
-→ draft_wiki_entry(topic: "JWT Validation", raw_content: "...")
-  Suggested path:  docs/wiki/auth/jwt-validation.md
-  Inferred type:   reference
-  Suggested tags:  jwt, auth, middleware
-
-→ write_wiki_entry(..., dry_run: true)   ← validate first
-  Status: dry_run_ok
-
-→ write_wiki_entry(..., dry_run: false)  ← write
-  Status: written  |  Doc ID: docs:auth:jwt-validation
-```
-
-**3 write tools** (enabled with `WIKI_WRITE=1`):
-
-| Tool | What it does |
-|------|-------------|
-| `find_similar` | Duplicate detection with overlap ratios and update suggestions. |
-| `draft_wiki_entry` | Scaffold: suggested path, inferred frontmatter, glossary hits. |
-| `write_wiki_entry` | Validated write: path containment, schema checks, duplicate guards, dry-run. |
-
-**Safety:** path containment · frontmatter validation · duplicate detection · dry-run · overwrite protection
+Deprecated aliases (`list_documents`, `find_files`, `find_symbol`) are superseded by `search_documents` — still functional, no longer recommended.
 
 ---
 
@@ -311,203 +89,136 @@ Agent: I need to understand the token refresh flow.
 
 Most retrieval tools hand the agent a search box and hope for the best. doctree-mcp hands it a **tree**, and the bundled skills teach it how to walk one.
 
-- **MCP = structural primitives.** `search_documents`, `get_tree`, `navigate_tree`, `get_node_content`, `lookup_row` return tree positions the agent can reason over — not finished answers.
-- **Skills = procedural knowledge.** `/doc-read`, `/doc-write`, `/doc-lint` encode breadcrumb-style drill-down: search → outline → navigate → retrieve. The agent learns the *policy*, not just the API.
+- **MCP = structural primitives.** `search_documents`, `get_tree`, `navigate_tree`, `get_node_content`, `lookup_row` return tree positions the agent reasons over — not finished answers.
+- **Skills = procedural knowledge.** `/doc-read`, `/doc-write`, `/doc-lint` encode breadcrumb drill-down: search → outline → navigate → retrieve. The agent learns the *policy*, not just the API.
 
-That exact pairing doesn't exist cleanly elsewhere:
+That pairing doesn't exist cleanly elsewhere:
 
-| Approach | Primitive the agent sees | What the skill teaches | Gap |
+| Approach | Primitive | Skill teaches | Gap |
 |---|---|---|---|
-| Managed hybrid RAG (Cloudflare AI Search, Nia) | Flat chunks + similarity score | — (no skill) | Black-box score, no audit trail |
-| Tool-returns-answer (Context7) | 2 tools returning finished answers | Query shape | Agent can't reason about what was skipped |
+| Managed hybrid RAG (Cloudflare AI Search, Nia) | Flat chunks + similarity | — | Black-box score, no audit trail |
+| Tool-returns-answer (Context7) | 2 tools returning answers | Query shape | Agent can't reason about skipped content |
 | Skill-over-CLI (QMD) | CLI over flat search | Query expansion | No tree to navigate |
-| **doctree-mcp + `/doc-read`** | **Navigable tree** | **Breadcrumb drill-down, multi-instance routing, wiki compilation** | — |
+| **doctree-mcp + `/doc-read`** | **Navigable tree** | **Breadcrumbs, multi-instance routing, wiki compilation** | — |
 
-### Why iterative retrieval wins as a prestige pattern
+**Why iterative retrieval wins:**
 
-- **Context rot is real.** Stuffing a 1M-token window with retrieved chunks degrades output. Breadcrumb navigation keeps working memory small — the agent pulls only the subtree it needs.
-- **Auditability is shippable.** `search_documents → get_tree → navigate_tree → get_node_content` is a replayable trail a human reviewer can read. A cosine-similarity score is not. Regulated industries (finance, health, legal) can ship the former.
-- **Fewer, navigable primitives beat tool sprawl.** The same bet Cloudflare made with Code Mode: progressive disclosure over granular tool catalogs.
+- **Context rot.** Stuffing a 1M-token window with chunks degrades output. Breadcrumb navigation keeps working memory small.
+- **Auditability.** `search_documents → get_tree → navigate_tree → get_node_content` is a replayable trail. A cosine score is not. Regulated domains can ship the former.
+- **Progressive disclosure.** Fewer navigable primitives beat tool sprawl (cf. Cloudflare Code Mode).
 
-### Multi-instance: client-side federation via skills
-
-One skill, many doctree instances, one agent. The skill encodes the **routing policy**; the MCP config just lists the instances. Add or remove an instance without editing the skill:
-
-```json
-{
-  "mcpServers": {
-    "wiki":    { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./wiki" } },
-    "api":     { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./api-docs" } },
-    "tickets": { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_GLOB": "**/*.csv", "DOCS_ROOT": "./tickets" } }
-  }
-}
-```
-
-```
-Agent (guided by /doc-read):
-  1. "This is an architecture question → route to `wiki`."
-  2. search_documents on wiki  → get_tree → navigate_tree.
-  3. "Needs the ticket that drove it → lookup_row on `tickets`."
-  4. Compose answer with breadcrumb citations from both.
-```
-
-Server-side federation (e.g. `instance_ids: [...]`) is faster but hides the routing decision inside the server. Client-side federation through skills keeps the decision **legible, portable across MCP clients, and under version control with the rest of the repo**.
-
-### Where this pattern fits in the market
-
-- **Near-term (0–12mo):** managed hybrid RAG wins the commodity lane — one API call, no infra. Fine for "just index our docs."
-- **Medium-term (12–24mo):** iterative breadcrumb retrieval becomes the prestige pattern — pushed by context rot, audit requirements, and tool sprawl fatigue.
-- **Long-term:** the split hardens. Managed hybrid on one side, agentic iterative retrieval on the other. The squeezed middle — local hybrid with local rerankers — has neither one-click convenience nor iterative transparency.
-
-doctree-mcp is explicitly aimed at the agentic iterative side: local, auditable, composable, skill-teachable.
+**Multi-instance = client-side federation.** Register several doctree servers under different names; the `/doc-read` skill encodes the routing policy. Add or remove instances without touching the skill. See [Client setup → Multi-instance routing](./docs/CLIENTS.md#multi-instance-routing).
 
 ---
 
 ## The LLM Wiki Pattern
 
-doctree-mcp supports using your agent as a wiki maintainer — inspired by [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f):
-
 ```
 ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  Raw Sources     │     │  The Wiki        │     │  The Schema      │
-│  (immutable)     │ ──→ │  (LLM-maintained)│ ←── │  (you define)    │
-│                  │     │                  │     │                  │
-│  meeting notes   │     │  structured docs │     │  CLAUDE.md rules │
-│  articles        │     │  runbooks        │     │  frontmatter     │
-│  incident logs   │     │  how-to guides   │     │  directory layout │
+│  Raw Sources    │     │  The Wiki        │     │  The Schema     │
+│  (immutable)    │ ──→ │  (LLM-maintained)│ ←── │  (you define)   │
+│  notes · logs   │     │  runbooks · refs │     │  CLAUDE.md rules │
 └─────────────────┘     └─────────────────┘     └─────────────────┘
 ```
 
-See [docs/LLM-WIKI-GUIDE.md](docs/LLM-WIKI-GUIDE.md) for the full walkthrough.
+Inspired by [Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Full walkthrough: [docs/LLM-WIKI-GUIDE.md](./docs/LLM-WIKI-GUIDE.md).
 
 ---
 
-## Frontmatter for Better Search
+## Configuration (summary)
 
 ```yaml
 ---
 title: "Descriptive Title"
-description: "One-line summary — boosts search ranking"
-tags: [relevant, terms, here]
-type: runbook            # runbook | guide | reference | tutorial | architecture | adr
-category: auth           # any domain grouping
+description: "One-line summary — boosts ranking"
+tags: [relevant, terms]
+type: runbook          # runbook | guide | reference | tutorial | architecture | adr
+category: auth
 ---
 ```
 
-All frontmatter fields (except reserved ones) become **filter facets**:
+All non-reserved frontmatter fields become filter facets:
 
 ```
-search_documents("auth", filters: { "type": "runbook", "tags": ["production"] })
+search_documents("auth", filters: { type: "runbook", tags: ["production"] })
 ```
 
-## Glossary & Query Expansion
+**Common env vars:**
 
-Place `glossary.json` in your docs root:
+| Variable | Default | Description |
+|---|---|---|
+| `DOCS_ROOT` | `./docs` | Docs folder |
+| `DOCS_GLOB` | `**/*.md` | Comma-separated globs (`**/*.md,**/*.csv,**/*.jsonl`) |
+| `DOCS_ROOTS` | — | Weighted multi-collection (`./wiki:1.0,./rfcs:0.5`) |
+| `PORT` | `3100` | HTTP mode port |
+| `WIKI_WRITE` | *(unset)* | `1` enables write tools |
+| `GLOSSARY_PATH` | `$DOCS_ROOT/glossary.json` | Query-expansion glossary |
+
+Full reference: [docs/CONFIGURATION.md](./docs/CONFIGURATION.md).
+
+**Glossary** — place `glossary.json` in docs root for bidirectional query expansion:
 
 ```json
 { "CLI": ["command line interface"], "K8s": ["kubernetes"] }
 ```
 
-doctree-mcp also **auto-extracts** acronym definitions — patterns like "TLS (Transport Layer Security)" are detected and added automatically.
+Acronym definitions like `"TLS (Transport Layer Security)"` are also auto-extracted.
 
-## Multiple Collections
+**Structured data** — CSV/JSONL files become documents where each row is a tree node. Column roles (id, title, description, facets, URL) are auto-detected from headers. See [docs/STRUCTURED-DATA.md](./docs/STRUCTURED-DATA.md).
 
-Two ways to combine sources — pick based on whether you want **one ranked search** or **the agent to route**:
-
-**Weighted merge (one instance, one search):**
-
-```json
-{ "env": { "DOCS_ROOTS": "./wiki:1.0,./api-docs:0.8,./meeting-notes:0.3" } }
-```
-
-Higher-weighted collections rank higher in search results.
-
-**Separate instances (one agent, many trees):** run a doctree-mcp per corpus and let the `/doc-read` skill route between them. See [Multi-instance: client-side federation via skills](#multi-instance-client-side-federation-via-skills).
+---
 
 ## Running from Source
 
 ```bash
 git clone https://github.com/joesaby/doctree-mcp.git
-cd doctree-mcp
-bun install
+cd doctree-mcp && bun install
 
 DOCS_ROOT=./docs bun run serve          # stdio
 DOCS_ROOT=./docs bun run serve:http     # HTTP (port 3100)
 DOCS_ROOT=./docs bun run index          # CLI: inspect indexed output
+bun test
 ```
 
-## Structured Data
-
-doctree-mcp can index CSV and JSONL files alongside markdown. Each file becomes one document, each row/line becomes a tree node — searchable, navigable, and retrievable through the same tools.
-
-### CSV files
-
-Set `DOCS_GLOB=**/*.md,**/*.csv` to include CSV files. Column roles are auto-detected from header names:
-
-| Header pattern | Role | Example |
-|---------------|------|---------|
-| `issue key`, `key`, `id` | Row identity (used by `lookup_row`) | `PROJ-44` |
-| `summary`, `title`, `name` | Node title | `API Platform Readiness` |
-| `description`, `quick notes`, `objective` | Full-text searchable content | Free text |
-| `status`, `team`, `theme`, `architect` | Facet filters | `Done`, `Cloud Platform` |
-| `url`, `link` | External URL metadata | Issue tracker link |
-
-### JSONL files
-
-Set `DOCS_GLOB=**/*.md,**/*.jsonl` to include JSONL files. Schema auto-detected from first line's keys. Fields named `key`/`id` become the node title, `paths`/`pages` become relation content, `status`/`team`/`corpus` become facets.
-
-### Agent workflow with structured data
-
-```
-lookup_row("PROJ-44")                              → canonical record (O(1))
-search_documents("PROJ-44", limit: 5)              → related docs from JSONL indexes + markdown
-get_node_content(dor_doc_id, [relevant_sections])  → full document content
-```
-
-See [docs/specs/2026-04-17-structured-data.md](docs/specs/2026-04-17-structured-data.md) for the full design.
-
-## Configuration Reference
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DOCS_ROOT` | `./docs` | Path to your markdown folder |
-| `DOCS_GLOB` | `**/*.md` | Comma-separated glob patterns (e.g. `**/*.md,**/*.csv,**/*.jsonl`) |
-| `DOCS_ROOTS` | — | Multiple weighted collections |
-| `MAX_DEPTH` | `6` | Max heading depth to index |
-| `SUMMARY_LENGTH` | `200` | Characters in node summaries |
-| `PORT` | `3100` | HTTP server port |
-| `GLOSSARY_PATH` | `$DOCS_ROOT/glossary.json` | Abbreviation glossary |
-| `WIKI_WRITE` | *(unset)* | Set to `1` to enable write tools |
-| `WIKI_ROOT` | `$DOCS_ROOT` | Filesystem root for wiki writes |
-| `WIKI_DUPLICATE_THRESHOLD` | `0.35` | Overlap ratio for duplicate warning |
-| `CSV_MAX_TEXT_LENGTH` | `2000` | Truncate long CSV text fields for BM25 indexing |
-
-Full details: [docs/CONFIGURATION.md](docs/CONFIGURATION.md)
+---
 
 ## Performance
 
 | Operation | Time | Token cost |
-|-----------|------|------------|
-| Full index (900 docs) | 2-5s | 0 |
+|---|---|---|
+| Full index (900 docs) | 2–5s | 0 |
 | Incremental re-index | ~50ms | 0 |
-| Search | 5-30ms | ~300-1K tokens |
-| Tree outline | <1ms | ~200-800 tokens |
+| Search | 5–30ms | ~300–1K tokens |
+| Tree outline | <1ms | ~200–800 tokens |
+
+---
 
 ## Docs
 
-- [LLM Wiki Guide](docs/LLM-WIKI-GUIDE.md) — agent-maintained knowledge base walkthrough
-- [Architecture & Design](docs/DESIGN.md) — BM25 internals, tree navigation
-- [Configuration](docs/CONFIGURATION.md) — env vars, frontmatter, ranking tuning
-- [Competitive Analysis](docs/COMPETITIVE-ANALYSIS.md) — comparison with PageIndex, QMD, GitMCP
-- [Prompts source](src/prompts.ts) — MCP prompt templates (all clients)
-- [Skills: `/doc-read`](.claude/skills/doc-read/SKILL.md), [`/doc-write`](.claude/skills/doc-write/SKILL.md), [`/doc-lint`](.claude/skills/doc-lint/SKILL.md) — Claude Code slash commands
+**Setup & operation**
+- [Operation Modes](./docs/OPERATION-MODES.md) — stdio · HTTP · CLI
+- [Client Setup](./docs/CLIENTS.md) — Claude Code · Cursor · Windsurf · Codex · OpenCode · Claude Desktop
+- [Deployment](./docs/DEPLOY.md) — Railway · Fly.io · Render · Cloudflare Containers · Docker
+- [Configuration](./docs/CONFIGURATION.md) — env vars, frontmatter, ranking tuning
+
+**Patterns & concepts**
+- [LLM Wiki Guide](./docs/LLM-WIKI-GUIDE.md) — agent-maintained knowledge base walkthrough
+- [Structured Data](./docs/STRUCTURED-DATA.md) — CSV / JSONL indexing
+- [Architecture & Design](./docs/DESIGN.md) — BM25 internals, tree navigation
+- [Competitive Analysis](./docs/COMPETITIVE-ANALYSIS.md) — PageIndex, QMD, GitMCP, Context7, managed RAG
+
+**Source**
+- [Prompts](./src/prompts.ts) — MCP prompt templates
+- Skills: [`/doc-read`](./.claude/skills/doc-read/SKILL.md) · [`/doc-write`](./.claude/skills/doc-write/SKILL.md) · [`/doc-lint`](./.claude/skills/doc-lint/SKILL.md)
+
+---
 
 ## Standing on Shoulders
 
-- **[PageIndex](https://pageindex.ai)** — Hierarchical tree navigation
-- **[Pagefind](https://pagefind.app)** by **[CloudCannon](https://cloudcannon.com)** — BM25 scoring, positional index, filter facets
-- **[Bun.markdown](https://bun.sh)** by **[Oven](https://oven.sh)** — Native CommonMark parser
-- **[Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** — The LLM-maintained wiki pattern
+- **[PageIndex](https://pageindex.ai)** — hierarchical tree navigation
+- **[Pagefind](https://pagefind.app)** by [CloudCannon](https://cloudcannon.com) — BM25 scoring, positional index, facets
+- **[Bun.markdown](https://bun.sh)** by [Oven](https://oven.sh) — native CommonMark parser
+- **[Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)** — the LLM-maintained wiki pattern
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Give your AI agent a markdown knowledge base it can search, browse, and write to
 
 doctree-mcp is an [MCP](https://modelcontextprotocol.io/) server that indexes your markdown, CSV, and JSONL files and exposes them as structured tools. Your agent gets BM25 search, a navigable table of contents, exact key-based row lookup for structured data, and (optionally) the ability to write and maintain docs.
 
+**The pitch in one line:** MCP provides the structural primitives (a navigable tree + BM25 + glossary), the included skills provide the procedural knowledge (how to walk the tree), and together the agent behaves like a trained research librarian — not a one-shot searcher. See [The Skill + MCP Pattern](#the-skill--mcp-pattern).
+
 ---
 
 ## Quick Start
@@ -305,6 +307,62 @@ Agent: I need to understand the token refresh flow.
 
 ---
 
+## The Skill + MCP Pattern
+
+Most retrieval tools hand the agent a search box and hope for the best. doctree-mcp hands it a **tree**, and the bundled skills teach it how to walk one.
+
+- **MCP = structural primitives.** `search_documents`, `get_tree`, `navigate_tree`, `get_node_content`, `lookup_row` return tree positions the agent can reason over — not finished answers.
+- **Skills = procedural knowledge.** `/doc-read`, `/doc-write`, `/doc-lint` encode breadcrumb-style drill-down: search → outline → navigate → retrieve. The agent learns the *policy*, not just the API.
+
+That exact pairing doesn't exist cleanly elsewhere:
+
+| Approach | Primitive the agent sees | What the skill teaches | Gap |
+|---|---|---|---|
+| Managed hybrid RAG (Cloudflare AI Search, Nia) | Flat chunks + similarity score | — (no skill) | Black-box score, no audit trail |
+| Tool-returns-answer (Context7) | 2 tools returning finished answers | Query shape | Agent can't reason about what was skipped |
+| Skill-over-CLI (QMD) | CLI over flat search | Query expansion | No tree to navigate |
+| **doctree-mcp + `/doc-read`** | **Navigable tree** | **Breadcrumb drill-down, multi-instance routing, wiki compilation** | — |
+
+### Why iterative retrieval wins as a prestige pattern
+
+- **Context rot is real.** Stuffing a 1M-token window with retrieved chunks degrades output. Breadcrumb navigation keeps working memory small — the agent pulls only the subtree it needs.
+- **Auditability is shippable.** `search_documents → get_tree → navigate_tree → get_node_content` is a replayable trail a human reviewer can read. A cosine-similarity score is not. Regulated industries (finance, health, legal) can ship the former.
+- **Fewer, navigable primitives beat tool sprawl.** The same bet Cloudflare made with Code Mode: progressive disclosure over granular tool catalogs.
+
+### Multi-instance: client-side federation via skills
+
+One skill, many doctree instances, one agent. The skill encodes the **routing policy**; the MCP config just lists the instances. Add or remove an instance without editing the skill:
+
+```json
+{
+  "mcpServers": {
+    "wiki":    { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./wiki" } },
+    "api":     { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./api-docs" } },
+    "tickets": { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_GLOB": "**/*.csv", "DOCS_ROOT": "./tickets" } }
+  }
+}
+```
+
+```
+Agent (guided by /doc-read):
+  1. "This is an architecture question → route to `wiki`."
+  2. search_documents on wiki  → get_tree → navigate_tree.
+  3. "Needs the ticket that drove it → lookup_row on `tickets`."
+  4. Compose answer with breadcrumb citations from both.
+```
+
+Server-side federation (e.g. `instance_ids: [...]`) is faster but hides the routing decision inside the server. Client-side federation through skills keeps the decision **legible, portable across MCP clients, and under version control with the rest of the repo**.
+
+### Where this pattern fits in the market
+
+- **Near-term (0–12mo):** managed hybrid RAG wins the commodity lane — one API call, no infra. Fine for "just index our docs."
+- **Medium-term (12–24mo):** iterative breadcrumb retrieval becomes the prestige pattern — pushed by context rot, audit requirements, and tool sprawl fatigue.
+- **Long-term:** the split hardens. Managed hybrid on one side, agentic iterative retrieval on the other. The squeezed middle — local hybrid with local rerankers — has neither one-click convenience nor iterative transparency.
+
+doctree-mcp is explicitly aimed at the agentic iterative side: local, auditable, composable, skill-teachable.
+
+---
+
 ## The LLM Wiki Pattern
 
 doctree-mcp supports using your agent as a wiki maintainer — inspired by [Andrej Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f):
@@ -354,11 +412,17 @@ doctree-mcp also **auto-extracts** acronym definitions — patterns like "TLS (T
 
 ## Multiple Collections
 
+Two ways to combine sources — pick based on whether you want **one ranked search** or **the agent to route**:
+
+**Weighted merge (one instance, one search):**
+
 ```json
 { "env": { "DOCS_ROOTS": "./wiki:1.0,./api-docs:0.8,./meeting-notes:0.3" } }
 ```
 
 Higher-weighted collections rank higher in search results.
+
+**Separate instances (one agent, many trees):** run a doctree-mcp per corpus and let the `/doc-read` skill route between them. See [Multi-instance: client-side federation via skills](#multi-instance-client-side-federation-via-skills).
 
 ## Running from Source
 

--- a/docs/CLIENTS.md
+++ b/docs/CLIENTS.md
@@ -1,0 +1,211 @@
+# Client Setup
+
+Per-client configuration for stdio mode. All clients use the same MCP server — just replace `./docs` with your actual docs path.
+
+For remote/hosted setups see the [Deployment guide](./DEPLOY.md). For a mode overview see [Operation Modes](./OPERATION-MODES.md).
+
+> **One-shot setup:** `bunx doctree-mcp init` writes the right config for your tool, plus hooks and wiki conventions. The snippets below are what it would produce — use them if you prefer to configure manually.
+
+---
+
+## Claude Code
+
+`.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "doctree": {
+      "command": "bunx",
+      "args": ["doctree-mcp"],
+      "env": {
+        "DOCS_ROOT": "./docs",
+        "WIKI_WRITE": "1"
+      }
+    }
+  }
+}
+```
+
+**Workflow prompts:** `/doc-read`, `/doc-write`, `/doc-lint` slash commands.
+
+**Lint hook** — add to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "write_wiki_entry",
+        "hooks": [{ "type": "command", "command": "bunx doctree-mcp lint" }]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Cursor
+
+`.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "doctree": {
+      "command": "bunx",
+      "args": ["doctree-mcp"],
+      "env": {
+        "DOCS_ROOT": "./docs",
+        "WIKI_WRITE": "1"
+      }
+    }
+  }
+}
+```
+
+**Workflow prompts:** `doc-read`, `doc-write`, `doc-lint` from the chat panel.
+
+**Lint hook** — `.cursor/hooks.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "afterMCPExecution": [{ "command": "bunx doctree-mcp lint" }]
+  }
+}
+```
+
+**Rules** — commit `.cursor/rules/doctree-wiki.mdc` (created by `bunx doctree-mcp init`).
+
+---
+
+## Windsurf
+
+`.windsurf/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "doctree": {
+      "command": "bunx",
+      "args": ["doctree-mcp"],
+      "env": {
+        "DOCS_ROOT": "./docs",
+        "WIKI_WRITE": "1"
+      }
+    }
+  }
+}
+```
+
+**Workflow prompts:** `doc-read`, `doc-write`, `doc-lint` from Cascade.
+
+**Lint hook** — `.windsurf/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "post_mcp_tool_use": [{ "command": "bunx doctree-mcp lint" }]
+  }
+}
+```
+
+---
+
+## Codex CLI
+
+`.codex/config.toml`:
+
+```toml
+[mcp_servers.doctree]
+command = "bunx"
+args = ["doctree-mcp"]
+
+[mcp_servers.doctree.env]
+DOCS_ROOT = "./docs"
+WIKI_WRITE = "1"
+```
+
+**Workflow prompts:** `doc-read`, `doc-write`, `doc-lint` MCP prompts.
+
+**Lint hook:** Codex hooks only intercept Bash today. Run `bunx doctree-mcp lint` manually or use the `doc-lint` prompt for audits.
+
+---
+
+## OpenCode
+
+`opencode.json`:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "doctree": {
+        "command": "bunx",
+        "args": ["doctree-mcp"],
+        "env": {
+          "DOCS_ROOT": "./docs",
+          "WIKI_WRITE": "1"
+        }
+      }
+    }
+  }
+}
+```
+
+**Lint plugin** — `.opencode/plugins/doctree-lint.js`:
+
+```javascript
+export const DoctreeLintPlugin = async ({ $ }) => ({
+  "tool.execute.after": async (event) => {
+    if (event?.tool?.name === "write_wiki_entry") {
+      try { await $`bunx doctree-mcp lint`; } catch {}
+    }
+  },
+});
+```
+
+---
+
+## Claude Desktop
+
+[Claude Desktop config](https://modelcontextprotocol.io/quickstart/user):
+
+```json
+{
+  "mcpServers": {
+    "doctree": {
+      "command": "bunx",
+      "args": ["doctree-mcp"],
+      "env": {
+        "DOCS_ROOT": "/absolute/path/to/your/docs"
+      }
+    }
+  }
+}
+```
+
+> Claude Desktop doesn't support project-level hooks. Use `bunx doctree-mcp lint` manually or invoke the `doc-lint` MCP prompt.
+
+**Pointing Desktop at a remote server?** See [Deployment guide: connecting Claude Desktop via `mcp-remote`](./DEPLOY.md#claude-desktop-via-mcp-remote).
+
+---
+
+## Multi-instance routing
+
+Register several doctree servers under different names and let the `/doc-read` skill route between them:
+
+```json
+{
+  "mcpServers": {
+    "wiki":    { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./wiki" } },
+    "api":     { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./api-docs" } },
+    "tickets": { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_GLOB": "**/*.csv", "DOCS_ROOT": "./tickets" } }
+  }
+}
+```
+
+See the [skill + MCP pattern](../README.md#the-skill--mcp-pattern) in the README for why client-side federation via skills beats server-side fan-out.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,273 @@
+# Deployment Guide
+
+How to run doctree-mcp in [HTTP mode](./OPERATION-MODES.md#http-mode-remoteshared) on common platforms. All options expose:
+
+- `POST /mcp` — Streamable HTTP MCP endpoint
+- `GET /health` — `{ "status": "ok", "document_count": N, "total_nodes": N }`
+
+The repo ships platform configs: `Dockerfile`, `railway.json`, `fly.toml`, `smithery.yaml`.
+
+---
+
+## Choosing a platform
+
+| Platform | Best for | Build system | Cold start |
+|---|---|---|---|
+| [Railway](#railway) | Fastest setup, GitHub-connected | Nixpacks (Bun) | ~1–2s |
+| [Fly.io](#flyio) | Global edges, auto-stop | Dockerfile | ~2–3s |
+| [Render](#render) | Free tier, simple | Dockerfile | ~5s |
+| [Cloudflare Containers](#cloudflare-containers) | Already on Cloudflare | Dockerfile | ~1–2s |
+| [Docker anywhere](#docker-anywhere) | Self-hosted, ECS, GKE | Dockerfile | depends |
+
+> **Cloudflare Workers is not supported.** doctree-mcp uses `Bun.markdown`, `Bun.hash`, `Bun.file`, and `Bun.Glob`, which aren't available in the Workers runtime. Use **Cloudflare Containers** instead.
+
+---
+
+## Getting your docs onto the server
+
+The server needs `DOCS_ROOT` to point at readable markdown/CSV/JSONL. Three patterns:
+
+1. **Bake into the image (simplest).** Commit docs to the repo; the Dockerfile copies them in. Rebuild to update.
+2. **Git-clone at boot.** Add a startup step that `git clone`s a docs repo into `/app/docs`, then runs the server. Good for frequent updates.
+3. **Mount a volume.** Attach persistent storage (Fly volumes, Railway volumes, Cloudflare R2-as-fs) and point `DOCS_ROOT` at the mount.
+
+The sections below use option 1 unless otherwise noted.
+
+---
+
+## Railway
+
+Config: `railway.json` (already in repo).
+
+```json
+{
+  "build": { "builder": "NIXPACKS", "buildCommand": "bun install --production" },
+  "deploy": {
+    "startCommand": "bun run serve:http",
+    "healthcheckPath": "/health"
+  }
+}
+```
+
+### Deploy
+
+1. Push your fork to GitHub.
+2. On railway.app: **New Project → Deploy from GitHub → select your fork**.
+3. Under **Variables**, set:
+   - `DOCS_ROOT` — e.g. `./docs` if docs are in-repo, or path to a mounted volume
+   - `WIKI_WRITE` — `1` to enable write tools (optional)
+   - `DOCS_GLOB`, `MAX_DEPTH`, etc. — see [CONFIGURATION.md](./CONFIGURATION.md)
+4. Railway picks up `PORT` automatically; the server reads it via `process.env.PORT`.
+
+### Test
+
+```bash
+curl https://<your-project>.up.railway.app/health
+```
+
+Expect `{"status":"ok",…}`. Then point an MCP client at `https://<your-project>.up.railway.app/mcp`.
+
+---
+
+## Fly.io
+
+Config: `fly.toml` (already in repo).
+
+```toml
+app = "doctree-mcp"
+primary_region = "iad"
+
+[env]
+  PORT = "3100"
+  DOCS_ROOT = "./docs"
+
+[http_service]
+  internal_port = 3100
+  force_https = true
+  auto_stop_machines = "stop"
+  min_machines_running = 0
+```
+
+### Deploy
+
+```bash
+fly launch --no-deploy    # pick app name, region; skip DB prompts
+fly secrets set WIKI_WRITE=1 DOCS_GLOB="**/*.md,**/*.csv"
+fly deploy
+```
+
+### Test
+
+```bash
+curl https://doctree-mcp.fly.dev/health
+fly logs                  # watch boot + index stats
+```
+
+### Persistent docs via volume
+
+```bash
+fly volumes create docs_data --size 1
+# then in fly.toml:
+#   [mounts]
+#     source = "docs_data"
+#     destination = "/app/docs"
+```
+
+SSH in with `fly ssh console` to populate `/app/docs`, or bake a git-clone step into the Dockerfile.
+
+---
+
+## Render
+
+No repo config needed — Render reads the `Dockerfile` directly.
+
+### Deploy
+
+1. On render.com: **New → Web Service → Build and deploy from a Git repository**.
+2. Select your fork. Render auto-detects the Dockerfile.
+3. **Environment:** set
+   - `DOCS_ROOT=/app/docs`
+   - `WIKI_WRITE=1` (optional)
+   - any of [CONFIGURATION.md](./CONFIGURATION.md) vars
+4. **Health Check Path:** `/health`
+5. **Port:** Render injects `PORT` — the Dockerfile's `EXPOSE 3100` is just a default.
+
+### Test
+
+```bash
+curl https://<your-service>.onrender.com/health
+```
+
+### Persistent docs
+
+Render disks mount at a path you specify — mount at `/app/docs` and populate via the shell tab or a pre-deploy git clone.
+
+---
+
+## Cloudflare Containers
+
+Cloudflare Containers run your Dockerfile as an isolated instance fronted by a Worker. This is the Cloudflare path that actually works for doctree-mcp — **not Workers**, which lacks the Bun runtime.
+
+### Deploy
+
+1. Install wrangler: `npm i -g wrangler`.
+2. Add a `wrangler.toml`:
+
+   ```toml
+   name = "doctree-mcp"
+   compatibility_date = "2025-10-01"
+
+   [[containers]]
+   name = "doctree"
+   image = "./Dockerfile"
+   instances = 1
+   ```
+
+3. Add a Worker entry that forwards requests to the container binding (see [Cloudflare Containers docs](https://developers.cloudflare.com/containers/)).
+4. Set secrets:
+
+   ```bash
+   wrangler secret put DOCS_ROOT
+   wrangler secret put WIKI_WRITE
+   ```
+
+5. `wrangler deploy`.
+
+### Test
+
+```bash
+curl https://doctree-mcp.<your-account>.workers.dev/health
+```
+
+### Docs source
+
+Containers are ephemeral — bake docs into the image or have the container pull from R2/KV at boot.
+
+---
+
+## Docker anywhere
+
+The shipped `Dockerfile` works on any Docker runtime (ECS, GKE, Nomad, Kubernetes, bare VM, Coolify, Dokku).
+
+### Build & run
+
+```bash
+docker build -t doctree-mcp .
+docker run -d \
+  -p 3100:3100 \
+  -e DOCS_ROOT=/app/docs \
+  -e WIKI_WRITE=1 \
+  -v "$(pwd)/docs:/app/docs" \
+  --name doctree-mcp \
+  doctree-mcp
+```
+
+### Test
+
+```bash
+curl http://localhost:3100/health
+```
+
+### Kubernetes readiness/liveness
+
+```yaml
+readinessProbe:
+  httpGet: { path: /health, port: 3100 }
+  initialDelaySeconds: 5
+livenessProbe:
+  httpGet: { path: /health, port: 3100 }
+  periodSeconds: 30
+```
+
+---
+
+## Connecting clients to a hosted server
+
+### Remote MCP (Claude Code, Cursor, Windsurf)
+
+Clients supporting Streamable HTTP can connect directly:
+
+```json
+{
+  "mcpServers": {
+    "doctree": { "url": "https://doctree-mcp.example.com/mcp" }
+  }
+}
+```
+
+### Claude Desktop via `mcp-remote`
+
+Claude Desktop only speaks stdio. Bridge with [`mcp-remote`](https://github.com/geelen/mcp-remote):
+
+```json
+{
+  "mcpServers": {
+    "doctree": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://doctree-mcp.example.com/mcp"]
+    }
+  }
+}
+```
+
+---
+
+## Smoke test checklist
+
+After any deploy:
+
+```bash
+# 1. Health endpoint returns ok
+curl -fsS https://<host>/health | jq .
+# {"status":"ok","document_count":42,"total_nodes":210}
+
+# 2. MCP endpoint responds to an initialize request
+curl -s -X POST https://<host>/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+
+# 3. Point a real client at /mcp and run: search_documents("hello")
+```
+
+If `document_count` is `0`, `DOCS_ROOT` is wrong or the docs didn't make it into the image. See [Getting your docs onto the server](#getting-your-docs-onto-the-server).

--- a/docs/OPERATION-MODES.md
+++ b/docs/OPERATION-MODES.md
@@ -1,0 +1,88 @@
+# Operation Modes
+
+doctree-mcp runs in three modes. Pick based on where the agent lives and who needs access.
+
+| Mode | Transport | Use when | Guide |
+|---|---|---|---|
+| **stdio** (default) | Local subprocess | Single developer, agent runs on your machine | [Client setup](./CLIENTS.md) |
+| **HTTP** | Streamable HTTP | Team/shared/remote agents, CI, web clients | [Deployment](./DEPLOY.md) |
+| **CLI** | Shell invocation | Setup, linting, debugging (no agent) | [CLI commands](#cli-mode) below |
+
+---
+
+## stdio mode (local)
+
+The MCP client (Claude Code, Cursor, Windsurf, Codex, OpenCode, Claude Desktop) spawns doctree-mcp as a subprocess and talks over stdin/stdout. Indexing happens at startup; state lives in the subprocess.
+
+**Start manually** (you usually don't — the client launches it):
+
+```bash
+DOCS_ROOT=./docs bun run serve
+```
+
+**Configure your AI tool:** see [Client setup](./CLIENTS.md) for copy-paste configs for each supported client.
+
+**When to choose:** one user, local docs, no network needed.
+
+---
+
+## HTTP mode (remote/shared)
+
+A long-running process exposes `/mcp` (Streamable HTTP) + `/health`. Multiple clients connect to one index; indexing happens once at boot.
+
+**Start manually:**
+
+```bash
+DOCS_ROOT=./docs bun run serve:http
+# → http://localhost:3100/mcp
+# → http://localhost:3100/health
+```
+
+**Test locally:**
+
+```bash
+curl http://localhost:3100/health
+# {"status":"ok","document_count":42,"total_nodes":210}
+```
+
+**Deploy to a platform** — see [Deployment guide](./DEPLOY.md):
+
+- [Railway](./DEPLOY.md#railway) — Nixpacks, one-click from GitHub
+- [Fly.io](./DEPLOY.md#flyio) — global edges, ships with `fly.toml`
+- [Render](./DEPLOY.md#render) — Dockerfile-based
+- [Cloudflare Containers](./DEPLOY.md#cloudflare-containers) — serverless containers (Workers won't work — Bun runtime required)
+- [Docker anywhere](./DEPLOY.md#docker-anywhere) — ECS, GKE, Nomad, bare metal
+
+**Transport note:** the server is stateless Streamable HTTP, so any MCP client supporting remote transports can connect — including Claude Desktop via `mcp-remote`.
+
+**When to choose:** team shares one corpus · agent runs in CI or a hosted service · docs live on a server, not your laptop.
+
+---
+
+## CLI mode
+
+Utility commands that don't start a server:
+
+```bash
+bunx doctree-mcp init           # scaffold a wiki + configure AI tool(s)
+bunx doctree-mcp lint           # audit orphans, stubs, broken links, missing frontmatter
+DOCS_ROOT=./docs bun run index  # debug: inspect the indexed output (tree + facets)
+```
+
+- `init` accepts `--claude-code`, `--cursor`, `--windsurf`, `--codex`, `--opencode`, or `--all`. See [LLM Wiki Guide](./LLM-WIKI-GUIDE.md).
+- `lint` is what the post-write hook fires. It also runs standalone for CI checks.
+- `bun run index` is for debugging the indexer — it prints the tree that the MCP server would expose.
+
+---
+
+## Picking a mode
+
+| If… | Use |
+|---|---|
+| Just you on a laptop | stdio |
+| Team members share one docs repo | HTTP, hosted |
+| CI or a deployed agent needs docs | HTTP, hosted |
+| Claude Desktop against a remote corpus | HTTP + `mcp-remote` |
+| Setting up or auditing a wiki | CLI |
+
+Env vars apply to all modes — see [CONFIGURATION.md](./CONFIGURATION.md).

--- a/docs/STRUCTURED-DATA.md
+++ b/docs/STRUCTURED-DATA.md
@@ -1,0 +1,111 @@
+# Structured Data (CSV + JSONL)
+
+doctree-mcp indexes CSV and JSONL files alongside markdown. Each file becomes one `IndexedDocument`; each row becomes a `TreeNode`. The same five read tools (`search_documents`, `get_tree`, `get_node_content`, `navigate_tree`, `lookup_row`) work across all three formats.
+
+For end-to-end operation and deployment see [Operation Modes](./OPERATION-MODES.md) and [Deployment](./DEPLOY.md).
+
+---
+
+## Enable it
+
+Add the globs to `DOCS_GLOB`:
+
+```bash
+DOCS_GLOB="**/*.md,**/*.csv,**/*.jsonl"
+```
+
+Default is `**/*.md` — nothing changes for existing deployments until you opt in.
+
+---
+
+## CSV files
+
+One document per file, one node per row, column roles auto-detected from headers.
+
+| Header pattern | Role | Example |
+|---|---|---|
+| `issue key`, `key`, `id`, `uuid` | Row identity → enables `lookup_row` | `PROJ-44` |
+| `summary`, `title`, `name` | Node title | `API Platform Readiness` |
+| `description`, `quick notes`, `objective` | Full-text body (BM25-indexed) | *(free text)* |
+| `status`, `team`, `theme`, `architect`, `category` | Filter facets | `Done`, `Cloud Platform` |
+| `url`, `link` | External URL metadata | ticket-tracker URL |
+
+Long text fields are truncated at `CSV_MAX_TEXT_LENGTH` (default `2000`) for BM25 indexing; the full value is still returned by `get_node_content`.
+
+---
+
+## JSONL files
+
+One document per file, one node per line. Schema is detected from the first line's keys.
+
+| Key pattern | Role |
+|---|---|
+| `key`, `id`, `uuid` | Row identity → `lookup_row` |
+| `title`, `name`, `summary` | Node title |
+| `paths`, `pages`, `references`, `links` | Relation content (searchable + navigable) |
+| `status`, `team`, `corpus`, `category`, `tags` | Filter facets |
+| `url`, `link` | External URL metadata |
+
+Arrays in relation fields are flattened into child nodes so `navigate_tree` can walk them.
+
+---
+
+## Agent workflow
+
+```
+lookup_row("PROJ-44")
+  → O(1) exact hit: canonical record from whichever file defines PROJ-44
+
+search_documents("PROJ-44", limit: 5)
+  → ranked matches across CSV, JSONL, and markdown — ticket row + every
+    wiki page, runbook, or design doc that references it
+
+get_node_content(doc_id, [node_ids])
+  → pull the specific rows / sections the agent decided it needs
+```
+
+The combination — O(1) key lookup plus BM25 cross-reference — is what makes structured data first-class. A canonical ticket export and a wiki of runbooks about those tickets become one searchable graph.
+
+---
+
+## Cross-referencing with JSONL
+
+Ship a JSONL "index" file that maps keys to related wiki paths:
+
+```jsonl
+{"key": "PROJ-44", "paths": ["runbooks/api-readiness.md", "architecture/platform.md"], "status": "active"}
+{"key": "PROJ-51", "paths": ["runbooks/oauth-rotation.md"], "status": "done"}
+```
+
+Now `search_documents("PROJ-44")` returns both the ticket row (from CSV) and every page listed in the JSONL relations — a breadcrumb path from identifier to narrative without maintaining that mapping inside every markdown file.
+
+---
+
+## Multi-instance pattern
+
+Give each corpus its own doctree instance and let the `/doc-read` skill route:
+
+```json
+{
+  "mcpServers": {
+    "wiki":    { "command": "bunx", "args": ["doctree-mcp"], "env": { "DOCS_ROOT": "./wiki" } },
+    "tickets": { "command": "bunx", "args": ["doctree-mcp"],
+                  "env": { "DOCS_GLOB": "**/*.csv", "DOCS_ROOT": "./tickets" } },
+    "refs":    { "command": "bunx", "args": ["doctree-mcp"],
+                  "env": { "DOCS_GLOB": "**/*.jsonl", "DOCS_ROOT": "./refs" } }
+  }
+}
+```
+
+See [The Skill + MCP Pattern](../README.md#the-skill--mcp-pattern) for why client-side federation beats server-side fan-out for this use case.
+
+---
+
+## Configuration reference
+
+| Env var | Default | Description |
+|---|---|---|
+| `DOCS_GLOB` | `**/*.md` | Comma-separated patterns |
+| `CSV_MAX_TEXT_LENGTH` | `2000` | Truncate long CSV text for BM25 |
+
+Background: [design spec](./specs/2026-04-17-structured-data.md).


### PR DESCRIPTION
## Summary

Reposition the README around the **skill + MCP pattern** (structural primitives + procedural skills = trained research librarian), trim it hard, and split per-client setup and hosted deploy into their own focused guides that each link to platform-specific deployment and test steps.

## What changed

**README.md** (514 → ~190 lines)
- New one-line pitch + "The Skill + MCP Pattern" section: positioning table vs managed hybrid RAG (Cloudflare AI Search), Context7, QMD; rationale for iterative retrieval (context rot, auditability, progressive disclosure); multi-instance client-side federation via the `/doc-read` skill.
- New "Operation Modes" table (stdio · HTTP · CLI) linking into dedicated guides.
- Per-tool stdio config matrix and hosted deploy details moved out.

**New guides**
- `docs/OPERATION-MODES.md` — stdio vs HTTP vs CLI, when to pick each, decision table.
- `docs/CLIENTS.md` — stdio configs for Claude Code, Cursor, Windsurf, Codex CLI, OpenCode, Claude Desktop; lint hooks for each; multi-instance routing snippet that cross-links the Skill + MCP pattern.
- `docs/DEPLOY.md` — HTTP deploy walkthroughs for Railway, Fly.io, Render, Cloudflare Containers, and Docker anywhere. Explicit note that Cloudflare Workers is unsupported (Bun runtime deps). `mcp-remote` bridge for Claude Desktop. Smoke-test checklist (`/health` + MCP `initialize`) for every target.
- `docs/STRUCTURED-DATA.md` — user-facing CSV/JSONL guide extracted from the existing design spec, with an agent-workflow example and a multi-instance routing pattern.

## Follow-ups landing on this same branch

- v2 of `docs/COMPETITIVE-ANALYSIS.md` (April 2026 landscape, Cloudflare AI Search, Karpathy wiki cohort, honest "is the zero-LLM lane defensible" analysis).
- Audit + cross-link pass on `docs/LLM-WIKI-GUIDE.md`, `docs/CONFIGURATION.md`, `docs/DESIGN.md`.
- Triage `docs/specs/` (mark historical or fold into guides).

## Test plan

- [ ] README renders on GitHub — headings anchor correctly, new guide links resolve.
- [ ] Each guide's internal cross-links resolve (`../README.md#the-skill--mcp-pattern`, `./OPERATION-MODES.md`, `./DEPLOY.md#...`).
- [ ] `bun test` still passes (no code changes, but re-run as a sanity check).
- [ ] Spot-check a deploy path end-to-end (e.g. Railway): `curl /health` after deploy and connect a client to `/mcp`.

https://claude.ai/code/session_012pYSKHScHgJC8W9zgJgkq2