### PR TITLE
fix: port applicable fixes from treenav PR #35

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ This enables bidirectional query expansion: searching "CLI" also matches "comman
 - No classes in indexer (functional), class-based store (`DocumentStore`)
 - Bun test runner (`bun test`) with `.test.ts` files in `tests/`
 - Comments reference design influences: PageIndex, Pagefind, Bun.markdown
-- Reserved frontmatter keys (not used as facets): title, description, layout, permalink, slug, draft, date
+- Reserved frontmatter keys (not used as facets): title, description, layout, permalink, slug, draft, date, source_url, source_title, captured_at
 
 ## Frontmatter Best Practices for Indexed Docs
 

--- a/bin.ts
+++ b/bin.ts
@@ -7,6 +7,9 @@ if (sub === "init") {
 } else if (sub === "lint") {
   const { main } = await import('./src/cli-lint.ts');
   await main();
+} else if (sub === "serve:http") {
+  await import('./src/server-http.ts');
 } else {
+  // `doctree-mcp` or `doctree-mcp serve` → stdio MCP server
   await import('./src/server.ts');
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,7 +93,7 @@ category: auth       # any domain-specific grouping
 
 ### Reserved frontmatter keys
 
-These are used internally and not exposed as filter facets: `title`, `description`, `layout`, `permalink`, `slug`, `draft`, `date`.
+These are used internally and not exposed as filter facets: `title`, `description`, `layout`, `permalink`, `slug`, `draft`, `date`, `source_url`, `source_title`, `captured_at`.
 
 ### Auto-inferred `type` from directory structure
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -30,6 +30,9 @@ interface ParseState {
   content_buffer: string[];
   node_counter: number;
   doc_id: string;
+  /** 1-based line of the most recently located heading — the next heading
+   *  search starts after it so repeated heading titles get distinct lines. */
+  last_heading_line: number;
 }
 
 function createParseState(doc_id: string): ParseState {
@@ -40,6 +43,7 @@ function createParseState(doc_id: string): ParseState {
     content_buffer: [],
     node_counter: 0,
     doc_id,
+    last_heading_line: 0,
   };
 }
 
@@ -134,9 +138,14 @@ export function buildTree(markdown: string, doc_id: string): TreeNode[] {
           content: "",
           summary: "",
           word_count: 0,
-          line_start: findHeadingLine(lines, stripHtml(children), 0),
+          line_start: findHeadingLine(
+            lines,
+            stripHtml(children),
+            state.last_heading_line
+          ),
           line_end: -1,
         };
+        state.last_heading_line = node.line_start;
 
         if (parent_id) {
           const parent = state.nodes.find((n) => n.node_id === parent_id);
@@ -335,6 +344,10 @@ const RESERVED_FRONTMATTER_KEYS = new Set([
   "slug",
   "draft",
   "date",
+  // Capture metadata (e.g. from web-clipping tools) — provenance, not taxonomy
+  "source_url",
+  "source_title",
+  "captured_at",
 ]);
 
 function extractFacets(frontmatter: Frontmatter): Record<string, string[]> {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,7 +10,26 @@ import { z } from "zod";
 import type { DocumentStore } from "./store";
 import { formatSearchResults } from "./search-formatter";
 import type { WikiOptions } from "./curator";
-import type { GrepOutcome } from "./types";
+import type { GrepOutcome, FacetCounts } from "./types";
+
+/** Compact facet-count rendering for list_documents output. */
+function formatFacetCounts(counts: FacetCounts, maxValuesPerKey = 8): string {
+  const keys = Object.keys(counts);
+  if (keys.length === 0) return "";
+  const lines = keys.sort().map((key) => {
+    const entries = Object.entries(counts[key]).sort((a, b) => b[1] - a[1]);
+    const shown = entries
+      .slice(0, maxValuesPerKey)
+      .map(([val, n]) => `${val} (${n})`)
+      .join(", ");
+    const more =
+      entries.length > maxValuesPerKey
+        ? `, +${entries.length - maxValuesPerKey} more`
+        : "";
+    return `  ${key}: ${shown}${more}`;
+  });
+  return `\n\nFacets in this result set (use as \`filters\` in search_documents/list_documents):\n${lines.join("\n")}`;
+}
 
 export function formatGrepResult(outcome: GrepOutcome, pattern: string): string {
   if (outcome.hits.length === 0) {
@@ -152,7 +171,7 @@ export function registerTools(
   // ── Tool 1: list_documents ─────────────────────────────────────────
   server.tool(
     "list_documents",
-    "List all indexed markdown documents. Filter by tag or keyword in title/path. Returns document metadata without content — use get_tree to explore a specific document's structure.",
+    "List indexed documents and discover the available filter facets. Filter by tag, keyword, collection, or facet values. Returns document metadata (no content) plus facet counts for the result set — call this first when you need to know which facets/values exist before filtering search_documents.",
     {
       query: z
         .string()
@@ -162,6 +181,14 @@ export function registerTools(
         .string()
         .optional()
         .describe("Filter documents by frontmatter tag"),
+      collection: z
+        .string()
+        .optional()
+        .describe("Limit to one collection (e.g. 'docs' or a multi-root collection name)"),
+      filters: z
+        .record(z.union([z.string(), z.array(z.string())]))
+        .optional()
+        .describe('Facet filters, same shape as search_documents. Example: { "type": "runbook" }'),
       limit: z
         .number()
         .min(1)
@@ -174,8 +201,8 @@ export function registerTools(
         .default(0)
         .describe("Pagination offset"),
     },
-    async ({ query, tag, limit, offset }) => {
-      const result = store.listDocuments({ query, tag, limit, offset });
+    async ({ query, tag, collection, filters, limit, offset }) => {
+      const result = store.listDocuments({ query, tag, collection, filters, limit, offset });
 
       const summary = result.documents
         .map(
@@ -184,11 +211,13 @@ export function registerTools(
         )
         .join("\n\n");
 
+      const facetBlock = formatFacetCounts(result.facet_counts);
+
       return {
         content: [
           {
             type: "text" as const,
-            text: `Found ${result.total} documents (showing ${offset + 1}-${Math.min(offset + limit, result.total)}):\n\n${summary}\n\nUse get_tree with a doc_id to explore a document's section hierarchy.`,
+            text: `Found ${result.total} documents (showing ${Math.min(offset + 1, result.total)}-${Math.min(offset + limit, result.total)}):\n\n${summary}${facetBlock}\n\nUse get_tree with a doc_id to explore a document's section hierarchy.`,
           },
         ],
       };
@@ -207,6 +236,10 @@ export function registerTools(
         .string()
         .optional()
         .describe("Limit search to a specific document"),
+      collection: z
+        .string()
+        .optional()
+        .describe("Limit search to one collection (e.g. 'docs' or a multi-root collection name — see list_documents facet counts)"),
       filters: z
         .record(z.union([z.string(), z.array(z.string())]))
         .optional()
@@ -220,8 +253,8 @@ export function registerTools(
         .default(15)
         .describe("Max results"),
     },
-    async ({ query, doc_id, filters, limit }) => {
-      const results = store.searchDocuments(query, { limit, doc_id, filters });
+    async ({ query, doc_id, collection, filters, limit }) => {
+      const results = store.searchDocuments(query, { limit, doc_id, collection, filters });
       const formatted = formatSearchResults(results, store, query);
 
       return {

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -175,6 +175,31 @@ Six seven eight.
       expect(node.line_end).not.toBe(-1);
     }
   });
+
+  test("repeated heading titles get distinct ascending line_start", () => {
+    // "## Notes" appears three times — the heading search must resume after
+    // the previous match instead of restarting at line 0 each time.
+    const body = [
+      "# Guide", // line 1
+      "", // 2
+      "## Notes", // 3
+      "", // 4
+      "First notes.", // 5
+      "", // 6
+      "## Notes", // 7
+      "", // 8
+      "Second notes.", // 9
+      "", // 10
+      "## Notes", // 11
+      "", // 12
+      "Third notes.", // 13
+    ].join("\n");
+    const nodes = buildTree(body, "test:doc");
+
+    const notes = nodes.filter((n) => n.title === "Notes");
+    expect(notes.length).toBe(3);
+    expect(notes.map((n) => n.line_start)).toEqual([3, 7, 11]);
+  });
 });
 
 // ── indexFile integration tests ─────────────────────────────────────


### PR DESCRIPTION
Ports the doctree-mcp-applicable subset of [joesaby/treenav#35](https://github.com/joesaby/treenav/pull/35). The two projects have diverged, so treenav-only changes are **not** included: `compile_context` scoping, `DOCS_ROOTS`/`config.ts` multi-root, code-collection `CODE_WEIGHT`/noise patterns, and the RRF documentation rescale (this repo still uses the 2.0/5.0 ranking scale, so its docs are already correct).

## What's ported

- **`line_start` fix for repeated heading titles** (`src/indexer.ts`) — the `Bun.markdown` path called `findHeadingLine(lines, title, 0)`, restarting the scan at line 0 for every heading, so duplicate heading titles all collapsed onto the first occurrence's line. Now tracks `last_heading_line` and resumes after it. The regex fallback parser was already correct. Adds a regression test asserting three `## Notes` headings get distinct ascending `line_start` values.
- **Reserve `source_url`/`source_title`/`captured_at`** frontmatter keys — capture provenance (e.g. from web-clipping tools) shouldn't be surfaced as filter facets.
- **`bin.ts serve:http` routing** — `doctree-mcp serve:http` now starts the HTTP server; previously every non-`init`/`lint` subcommand silently started the stdio server.
- **`list_documents` facet discovery** — renders facet counts and accepts `collection` + `filters` params. The store already computed/supported these; the tool just never exposed them.
- **`search_documents` collection scope** — exposes the `collection` param the store already accepted.
- **Docs** — synced the reserved-key lists in `CLAUDE.md` and `docs/CONFIGURATION.md`.

## Not ported (optional follow-ups)

- `refresh_index` tool — a useful *feature* from the PR (re-scan roots, reload on content-hash change), but a new capability rather than a fix. Can port separately if wanted.
- Deprecating `navigate_tree` in favor of `get_node_content(include_descendants=true)` — skipped intentionally; `navigate_tree` is a deliberate core tool here and adding `include_descendants` would duplicate it.

## Testing

`bun test` — 213 pass / 0 fail. `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)